### PR TITLE
Add failing test for clicks inside tables

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -56,5 +56,12 @@ describe Capybara::Session do
       @session.click_link 'Link'
       @session.should have_content('Hello world')
     end
+
+    it 'should handle clicks in tables' do
+      @session.visit '/poltergeist/table'
+      @session.click_link 'Link'
+      @session.should have_content('Hello world')
+    end
+
   end
 end

--- a/spec/support/views/table.erb
+++ b/spec/support/views/table.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="http://twitter.github.com/bootstrap/1.4.0/bootstrap.min.css">
+</head>
+<body>
+<table>
+  <tbody>
+    <tr>
+      <th>Links</th>
+    </tr
+    <tr>
+      <td><a href="/">Link</a></td>
+    </tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
Hi,
I encountered a strange problem. Clicks inside tables are failing, but only if using Twitter Bootstrap. This is a failing test for the problem. If you remove Twitter Bootstrap the test passes.

Caveat: An internet connection is now required to run the specs.

Best regards,
Fabian
