### PR TITLE
Add Gemnasium dependency status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Version: 0.4.0
 
 [![Build Status](https://secure.travis-ci.org/jonleighton/poltergeist.png)](http://travis-ci.org/jonleighton/poltergeist)
+[![Dependency Status](https://gemnasium.com/jonleighton/poltergeist.png)](https://gemnasium.com/jonleighton/poltergeist)
 
 Poltergeist is a driver for [Capybara](https://github.com/jnicklas/capybara). It allows you to
 run your Capybara tests on a headless [WebKit](http://webkit.org) browser,


### PR DESCRIPTION
The faye-websocket gem dependency is behind, enough so where it feel intentional. Is there an issue with the latest versions? I hope it helps!
