### PR TITLE
Fix multi_json deprecated calls

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -114,7 +114,7 @@ module Capybara::Poltergeist
       message = { 'name' => name, 'args' => args }
       log message.inspect
 
-      json = MultiJson.decode(server.send(MultiJson.encode(message)))
+      json = MultiJson.load(server.send(MultiJson.dump(message)))
       log json.inspect
 
       if json['error']

--- a/spec/unit/browser_spec.rb
+++ b/spec/unit/browser_spec.rb
@@ -13,7 +13,7 @@ module Capybara::Poltergeist
       it 'should log requests and responses to the client' do
         request  = { 'name' => 'where is', 'args' => ["the love?"] }
         response = { 'response' => '<3' }
-        server.stub(:send).with(MultiJson.encode(request)).and_return(MultiJson.encode(response))
+        server.stub(:send).with(MultiJson.dump(request)).and_return(MultiJson.dump(response))
 
         subject.command('where is', 'the love?')
 


### PR DESCRIPTION
Replace deprecated MultiJson#decode and MultiJson#encode calls by MultiJson#load and MultiJson#dump.
