### PR TITLE
Fix BrowserError when setting a number value and a maxlength is present

### DIFF
--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -52,10 +52,10 @@ module Capybara::Poltergeist
         when 'file'
           command :select_file, value
         else
-          command :set, value
+          command :set, value.to_s
         end
       elsif tag_name == 'textarea'
-        command :set, value
+        command :set, value.to_s
       end
     end
 

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -32,11 +32,16 @@ describe Capybara::Session do
     describe 'Node#set' do
       before do
         @session.visit('/poltergeist/with_js')
-        @session.find(:css, '#change_me').set("Hello!")        
+        @session.find(:css, '#change_me').set("Hello!")
       end
 
       it 'should fire the change event' do
         @session.find(:css, '#changes').text.should == "Hello!"
+      end
+
+      it 'should accept numbers in a maxlength field' do
+        element = @session.find(:css, '#change_me_maxlength')
+        lambda { element.set 100 }.should_not raise_error(Capybara::Poltergeist::BrowserError)
       end
 
       it 'should fire the keydown event' do
@@ -44,7 +49,7 @@ describe Capybara::Session do
       end
 
       it 'should fire the keyup event' do
-        @session.find(:css, '#changes_on_keyup').text.should == "6"        
+        @session.find(:css, '#changes_on_keyup').text.should == "6"
       end
 
       it 'should fire the keypress event' do
@@ -52,7 +57,7 @@ describe Capybara::Session do
       end
 
       it 'should fire the focus event' do
-        @session.find(:css, '#changes_on_focus').text.should == "Focus"        
+        @session.find(:css, '#changes_on_focus').text.should == "Focus"
       end
 
       it 'should fire the blur event' do

--- a/spec/support/views/with_js.erb
+++ b/spec/support/views/with_js.erb
@@ -12,6 +12,7 @@
     <p><a id="remove">Remove</a></p>
 
     <p><input type="text" id="change_me"></p>
+    <p><input type="text" id="change_me_maxlength" maxlength="30"></p>
     <p id="changes"></p>
     <p id="changes_on_keydown"></p>
     <p id="changes_on_keyup"></p>


### PR DESCRIPTION
If setting a number and a maxLength is present the substr will fail.
This commit cast the value as a string before continuing 
