### PR TITLE
Add an option to prevent re-raising of Javascript errors in Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ end
     when communicating with PhantomJS. `nil` means wait forever. Default
     is 30.
 *   `:inspector` (Boolean, String) - See 'Remote Debugging', above.
+*   `:raise_errors` (Boolean) - When false, Javascript errors do not get re-raised in Ruby.
 
 ## Bugs ##
 

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -17,7 +17,7 @@ module Capybara::Poltergeist
     end
 
     def browser
-      @browser ||= Browser.new(server, client, logger)
+      @browser ||= Browser.new(server, client, logger, raise_errors)
     end
 
     def inspector
@@ -56,6 +56,10 @@ module Capybara::Poltergeist
     # logger should be an object that responds to puts, or nil
     def logger
       options[:logger] || (options[:debug] && STDERR)
+    end
+
+    def raise_errors
+      options.fetch(:raise_errors, true)
     end
 
     def visit(path)

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -160,6 +160,13 @@ module Capybara::Poltergeist
         # should not raise again
         @driver.evaluate_script("1+1").should == 2
       end
+
+      it "doesn't propagate a Javascript error to ruby if error raising disabled" do
+        driver = Capybara::Poltergeist::Driver.new(nil, :raise_errors => false)
+        driver.execute_script "setTimeout(function() { omg }, 0)"
+        sleep 0.01
+        expect { driver.execute_script "" }.to_not raise_error(JavascriptError)
+      end
     end
   end
 end


### PR DESCRIPTION
I had a crack at adding an option to prevent re-raising Javascript errors in Ruby as discussed in issue #46. When enabled, the errors are logged instead of raised and the response is returned.
