### PR TITLE
Pull MultiJSON feature-switching out

### DIFF
--- a/lib/capybara/poltergeist.rb
+++ b/lib/capybara/poltergeist.rb
@@ -12,6 +12,7 @@ module Capybara
     autoload :Util,            'capybara/poltergeist/util'
     autoload :Inspector,       'capybara/poltergeist/inspector'
     autoload :Spawn,           'capybara/poltergeist/spawn'
+    autoload :JSON,            'capybara/poltergeist/json'
 
     require 'capybara/poltergeist/errors'
   end

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -114,11 +114,7 @@ module Capybara::Poltergeist
       message = { 'name' => name, 'args' => args }
       log message.inspect
 
-      json = if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-        MultiJson.load(server.send(MultiJson.dump(message)))
-      else
-        MultiJson.decode(server.send(MultiJson.encode(message)))
-      end
+      json = JSON.load(server.send(JSON.dump(message)))
       log json.inspect
 
       if json['error']

--- a/lib/capybara/poltergeist/json.rb
+++ b/lib/capybara/poltergeist/json.rb
@@ -1,0 +1,25 @@
+module Capybara::Poltergeist
+  module JSON
+    def self.load(message)
+      if dumpy_multi_json?
+        MultiJson.load(message)
+      else
+        MultiJson.decode(message)
+      end
+    end
+
+    def self.dump(message)
+      if dumpy_multi_json?
+        MultiJson.dump(message)
+      else
+        MultiJson.encode(message)
+      end
+    end
+
+    private
+
+    def self.dumpy_multi_json?
+      MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
+    end
+  end
+end


### PR DESCRIPTION
Make Browser#command easier to understand by putting MultiJson feature switching in a new Capybara::Poltergeist::JSON module with a known interface.
