### PR TITLE
Documentation change for configuring non-transactional tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ end
 
 ## Setup  ##
 
-Because Poltergeist runs your web app in a separate process from the tests themselves, it is
+Because Poltergeist runs your web app on a separate thread from the tests themselves, it is
 essential that you ensure that your tests do not run inside transactions, or the data
 you create in your tests will not be available in the web app.
 


### PR DESCRIPTION
I added some documentation around how to set up Capybara and Poltergeist so that JavaScript tests do not run inside transactions, because of the multiple process architecture. 

We ran into this issue on a project and thought that this technique should be covered in the basic documentation for the project. The doc change reflects the way that we set things up in our test_helper.rb file.

Hopefully that's useful.

Cheers,
James
