### PR TITLE
Add js code to fire HTML5 input event

### DIFF
--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -101,6 +101,11 @@ class PoltergeistAgent.Node
     event.initEvent('change', true, false)
     @element.dispatchEvent(event)
 
+  input: ->
+    event = document.createEvent('HTMLEvents')
+    event.initEvent('input', true, false)
+    @element.dispatchEvent(event)
+
   keyupdowned: (eventName, keyCode) ->
     event = document.createEvent('UIEvents')
     event.initEvent(eventName, true, true)
@@ -170,6 +175,7 @@ class PoltergeistAgent.Node
       this.keyupdowned('keyup', keyCode)
 
     this.changed()
+    this.input()
     this.trigger('blur')
 
   isMultiple: ->

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -150,6 +150,13 @@ PoltergeistAgent.Node = (function() {
     return this.element.dispatchEvent(event);
   };
 
+  Node.prototype.input = function() {
+    var event;
+    event = document.createEvent('HTMLEvents');
+    event.initEvent('input', true, false);
+    return this.element.dispatchEvent(event);
+  };
+
   Node.prototype.keyupdowned = function(eventName, keyCode) {
     var event;
     event = document.createEvent('UIEvents');
@@ -241,6 +248,7 @@ PoltergeistAgent.Node = (function() {
       this.keyupdowned('keyup', keyCode);
     }
     this.changed();
+    this.input();
     return this.trigger('blur');
   };
 

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -80,6 +80,10 @@ describe Capybara::Session do
         @session.find(:css, '#changes').text.should == "Hello!"
       end
 
+      it 'fires the input event' do
+        @session.find(:css, '#changes_on_input').text.should == "Hello!"
+      end
+
       it 'accepts numbers in a maxlength field' do
         element = @session.find(:css, '#change_me_maxlength')
         element.set 100

--- a/spec/support/public/test.js
+++ b/spec/support/public/test.js
@@ -13,6 +13,9 @@ $(function() {
     .change(function(event) {
       $('#changes').text($(this).val())
     })
+    .bind('input', function(event) {
+      $('#changes_on_input').text($(this).val())
+    })
     .keydown(function(event) {
       $('#changes_on_keydown').text(increment)
     })

--- a/spec/support/views/with_js.erb
+++ b/spec/support/views/with_js.erb
@@ -18,6 +18,7 @@
       <input type="text" name="change_me_withname" id="change_me_withname">
     </p>
     <p id="changes"></p>
+    <p id="changes_on_input"></p>
     <p id="changes_on_keydown"></p>
     <p id="changes_on_keyup"></p>
     <p id="changes_on_focus"></p>


### PR DESCRIPTION
In addition to the change/keydown/keyup/keypress events, the HTML5 spec has an "input" event that's fired when input/textarea fields are changed (handles pasting, drag-and-drop, etc). I added code to fire that event.
