### PR TITLE
Support headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ end
 *   `:window_size` (Array) - The dimensions of the browser window in which to test, expressed
     as a 2-element array, e.g. [1024, 768]. Default: [1024, 768]
 
+## Request Headers ##
+
+Http request headers can be set with the following:
+
+page.driver.headers= {
+  "Cookie" => "foo=bar",
+  "Host" => "foo.com"
+}
+
 ## Bugs ##
 
 Please file bug reports on Github and include example code to reproduce the problem wherever
@@ -199,6 +208,7 @@ makes debugging easier). Running `rake autocompile` will watch the
     dimensions to which the browser window will be resized.
     (Tom Stuart) [Issue #53]
 *   Capybara 1.0 is no longer supported. Capybara ~> 1.1 is required.
+*   Added ability to set arbitrary http request headers
 
 #### Bug fixes ###
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -16,8 +16,8 @@ module Capybara::Poltergeist
       client.restart
     end
 
-    def visit(url)
-      command 'visit', url
+    def visit(url, headers)
+      command 'visit', url, headers
     end
 
     def current_url

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -40,9 +40,9 @@ class Poltergeist.Browser
     else
       throw new Poltergeist.ObsoleteNode
 
-  visit: (url) ->
+  visit: (url, headers) ->
     @state = 'loading'
-    @page.open(url)
+    @page.open(url, operation: "get", headers: headers)
 
   current_url: ->
     this.sendResponse @page.currentUrl()

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -56,9 +56,12 @@ Poltergeist.Browser = (function() {
     }
   };
 
-  Browser.prototype.visit = function(url) {
+  Browser.prototype.visit = function(url, headers) {
     this.state = 'loading';
-    return this.page.open(url);
+    return this.page.open(url, {
+      operation: "get",
+      headers: headers
+    });
   };
 
   Browser.prototype.current_url = function() {

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -3,6 +3,7 @@ module Capybara::Poltergeist
     DEFAULT_TIMEOUT = 30
 
     attr_reader :app, :app_server, :server, :client, :browser, :options
+    attr_accessor :headers
 
     def initialize(app, options = {})
       @app       = app
@@ -11,6 +12,7 @@ module Capybara::Poltergeist
       @inspector = nil
       @server    = nil
       @client    = nil
+      @headers   = {}
       if @options[:window_size]
         @width, @height = @options[:window_size]
       end
@@ -66,7 +68,7 @@ module Capybara::Poltergeist
     end
 
     def visit(path)
-      browser.visit app_server.url(path)
+      browser.visit app_server.url(path), @headers
     end
 
     def current_url
@@ -100,6 +102,7 @@ module Capybara::Poltergeist
 
     def reset!
       browser.reset
+      @headers = {}
     end
 
     def render(path, options = {})

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -95,6 +95,17 @@ module Capybara::Poltergeist
       end
     end
 
+    it 'allows request headers to be set' do
+      @driver.headers = {
+        "Cookie" => "foo=bar",
+        "Host" => "foo.com"
+      }
+      @driver.visit('/poltergeist/headers')
+      @driver.body.should include('COOKIE: foo=bar')
+      @driver.body.should include('HOST: foo.com')
+      @driver.reset!
+    end
+
     it 'supports executing multiple lines of javascript' do
       @driver.execute_script <<-JS
         var a = 1

--- a/spec/support/views/headers.erb
+++ b/spec/support/views/headers.erb
@@ -1,0 +1,3 @@
+<% for header in request.env.select {|k,v| k.match("^HTTP.*")} %>
+  <%=header[0].split('_',2)[1]%>: <%=header[1]%>
+<% end %>

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -61,5 +61,16 @@ module Capybara::Poltergeist
         subject.client
       end
     end
+
+    context 'when setting request headers' do
+      subject { Driver.new(nil) }
+
+      it "resets headers to empty hash after calling reset" do
+        subject.headers.should == {}
+        subject.headers = {"foo" => "bar"}
+        subject.reset!
+        subject.headers.should == {}
+      end
+    end
   end
 end


### PR DESCRIPTION
Ok I've recreated the pull request and addressed all the code review suggestions.  You also suggested to implement response_headers, but after some poking around phantomjs I think it might be best to just implement it in separate pull req.  Also all the tests pass except for one which fails for me in both master and my branch:

  1) Capybara::Session with poltergeist driver supports running multiple sessions at once
     Failure/Error: @session.visit('/')
     Capybara::Poltergeist::DeadClient:
       The PhantomJS client died while processing {"name":"visit","args":["http://127.0.0.1:55373/",{}]}
     # ./lib/capybara/poltergeist/server.rb:29:in `send'
     # ./lib/capybara/poltergeist/browser.rb:118:in`command'
     # ./lib/capybara/poltergeist/browser.rb:20:in `visit'
     # ./lib/capybara/poltergeist/driver.rb:71:in`visit'
     # ./spec/integration/session_spec.rb:116:in `block (3 levels) in <top (required)>'
