### PR TITLE
Clear error why the remote debugger could not be used

### DIFF
--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -129,8 +129,13 @@ module Capybara::Poltergeist
     end
 
     def debug
-      inspector.open
-      pause
+      if @options[:inspector]
+        inspector.open
+        pause
+      else
+        raise Error, "To use the remote debugging, you have to launch the driver " \
+                     "with `:inspector => true` configuration option"
+      end
     end
 
     def pause


### PR DESCRIPTION
Hello Jon,

I've added a simple code to raise an error when the remote debugging is used without properly launched driver

https://github.com/jonleighton/poltergeist/issues/47
