### PR TITLE
Fix typo in filename for Linux binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bit](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.6.1-li
 or [64
 bit](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.6.1-linux-x86_64-dynamic.tar.bz2&can=2&q=)
 binary.
-* Extract it: `sudo tar xvjf phantomjs-1.6.1-linux-*-dynamic.tar.gz -C /usr/local`
+* Extract it: `sudo tar xvjf phantomjs-1.6.1-linux-*-dynamic.tar.bz2 -C /usr/local`
 * Link it: `sudo ln -s /usr/local/phantomjs-1.6.1-linux*/bin/phantomjs /usr/local/bin/phantomjs`
 
 (Note that you cannot copy the `/usr/local/phantomjs/bin/phantomjs`


### PR DESCRIPTION
This changes the filename extension ".tar.gz" to "tar.bz2" to match the extension of the download file eg.
http://phantomjs.googlecode.com/files/phantomjs-1.6.1-linux-x86_64-dynamic.tar.bz2
