### PR TITLE
Adding a failing test case for an issue with click test

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -255,6 +255,16 @@ describe Capybara::Session do
             error.position.first.should == 150
           end
         end
+
+        context "two elements, positioned at the same location, of which one is flipped around" do
+          it 'detects click ability correctly' do
+            @session.visit '/poltergeist/click_test_issue'
+
+            expect {
+              @session.find(:css, '.front').click
+            }.to_not raise_error(Capybara::Poltergeist::ClickFailed)
+          end
+        end
       end
 
       it "can evaluate a statement ending with a semicolon" do

--- a/spec/support/views/click_test_issue.erb
+++ b/spec/support/views/click_test_issue.erb
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+  <head>
+    <title></title>
+    <style>
+      body {
+        margin: 0;
+      }
+      html, body, div {
+        width: 100%;
+        height: 100%;
+      }
+      .flippable {
+        -webkit-perspective: 1200;
+      }
+      .flippable > div {
+        -webkit-transform-style: preserve-3d;
+        -webkit-transition: -webkit-transform .33s;
+      }
+      .flippable:active > div {
+        -webkit-transform: rotateY(180deg);
+      }
+      .face {
+        position: absolute;
+        -webkit-backface-visibility: hidden;
+      }
+      .front {
+        /* Setting the z-index fixes the issue! */
+        /* z-index: 1; */
+        background: green;
+      }
+      .back {
+        background: red;
+        -webkit-transform: rotateY(180deg);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="flippable">
+      <div>
+        <div class="face front">
+          <a>Foo</a>
+        </div>
+        <div class="face back"></div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Involves two elements positioned in the same location, the latter is being turned around using `-webkit-transform: rotateY(180deg)`.

Seems to be more of an issue with phantomjs itself but thought you'd might be interested as to capture this issue somehow. I found a workaround for while creating the test case: Setting z-index.
