### PR TITLE
Fix for #126 (get text from title element)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ makes debugging easier). Running `rake autocompile` will watch the
 *   Don't blow up when `evaluate_script` is called with a cyclic
     structure.
 
+*   Fix the text method for title elements, so it doesn't return an
+    empty string.
+
 ### 0.7.0 ###
 
 #### Features ####

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -141,6 +141,7 @@ class PoltergeistAgent.Node
     @agent.document.evaluate('ancestor::body', @element, null, XPathResult.BOOLEAN_TYPE, null).booleanValue
 
   text: ->
+    return @element.textContent if @element.tagName == 'TITLE'
     return '' unless this.isVisible()
 
     if this.insideBody()

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -205,6 +205,9 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.text = function() {
     var el, i, node, results, text, _i, _ref;
+    if (this.element.tagName === 'TITLE') {
+      return this.element.textContent;
+    }
     if (!this.isVisible()) {
       return '';
     }

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -40,6 +40,12 @@ describe Capybara::Session do
         @session.current_path.should == '/'
       end
 
+      it "returns the text of a title element" do
+        @session.visit('/poltergeist/simple')
+        node = @session.find('//title')
+        node.text.should == "Test"
+      end
+
       context "when someone (*cough* prototype *cough*) messes with Array#toJSON" do
         before do
           @session.visit("/poltergeist/index")

--- a/spec/support/views/simple.erb
+++ b/spec/support/views/simple.erb
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html>
-<body>
-<a href="/">Link</a>
-</body>
+  <head>
+    <title>Test</title>
+  </head>
+
+  <body>
+    <a href="/">Link</a>
+  </body>
 </html>


### PR DESCRIPTION
The 'isVisible' method returned false for the title element, because they are set to display: none. I added an
extra guard clause in the text method before the visibility check, so it just returns the text when element is a title.
