### PR TITLE
join separate text nodes with a whitespace instead of nothing at all

### DIFF
--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -150,12 +150,15 @@ class PoltergeistAgent.Node
       el = @agent.document.body
 
     results = @agent.document.evaluate('.//text()[not(ancestor::script)]', el, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null)
-    text    = []
+    text    = ''
 
     for i in [0...results.snapshotLength]
       node = results.snapshotItem(i)
-      text.push node.textContent if this.isVisible(node.parentNode)
-    text.join ' '
+      if this.isVisible(node.parentNode)
+        text += node.textContent
+        text += ' ' if node.nextSibling?.nodeName == "BR"
+
+    text
 
   getAttribute: (name) ->
     if name == 'checked' || name == 'selected'

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -204,7 +204,7 @@ PoltergeistAgent.Node = (function() {
   };
 
   Node.prototype.text = function() {
-    var el, i, node, results, text, _i, _ref;
+    var el, i, node, results, text, _i, _ref, _ref1;
     if (this.element.tagName === 'TITLE') {
       return this.element.textContent;
     }
@@ -217,14 +217,17 @@ PoltergeistAgent.Node = (function() {
       el = this.agent.document.body;
     }
     results = this.agent.document.evaluate('.//text()[not(ancestor::script)]', el, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
-    text = [];
+    text = '';
     for (i = _i = 0, _ref = results.snapshotLength; 0 <= _ref ? _i < _ref : _i > _ref; i = 0 <= _ref ? ++_i : --_i) {
       node = results.snapshotItem(i);
       if (this.isVisible(node.parentNode)) {
-        text.push(node.textContent);
+        text += node.textContent;
+        if (((_ref1 = node.nextSibling) != null ? _ref1.nodeName : void 0) === "BR") {
+          text += ' ';
+        }
       }
     }
-    return text.join(' ');
+    return text;
   };
 
   Node.prototype.getAttribute = function(name) {


### PR DESCRIPTION
This should fix issue #139.

Just using `el.innertext`, as suggested by @carhartl won't work, since then we would lose the `[not(ancestor::script)]` part. Instead I just tally up all the text in an array and `join` it at the end with a space.

I don't know if you normally test these things (and where they should go), I couldn't find any appropriate place to put them. So here is the test just as a comment:

``` ruby
it "treats <br> as a space" do
   @session.visit '/poltergeist/simple'
   @session.find('//div').text.should == "Two lines of text"
end
```

Of course this also means that (in this case) `simple.erb` should have a `<div>Two lines<br>of text</div>`.
