### PR TITLE
Replace 'safari' with 'open' in Capybara::Poltergeist::Inspector

### DIFF
--- a/lib/capybara/poltergeist/inspector.rb
+++ b/lib/capybara/poltergeist/inspector.rb
@@ -1,6 +1,6 @@
 module Capybara::Poltergeist
   class Inspector
-    BROWSERS = %w(chromium chromium-browser google-chrome safari)
+    BROWSERS = %w(chromium chromium-browser google-chrome open)
 
     def self.detect_browser
       @browser ||= BROWSERS.find { |name| system("which #{name} &>/dev/null") }


### PR DESCRIPTION
Replace 'safari' with 'open' in Capybara::Poltergeist::Inspector, since there is no 'safari' CLI on Mac OS X.
