### PR TITLE
add Browser.clickCoordinates(x, y) to click a specific position on the screen

### DIFF
--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -127,6 +127,10 @@ class Poltergeist.Browser
         this.sendResponse(@last_click)
     , 5
 
+  clickCoordinates: (x, y) ->
+    this.page.sendEvent('click', x, y)
+    this.sendResponse(true)
+
   drag: (page_id, id, other_id) ->
     this.node(page_id, id).dragTo this.node(page_id, other_id)
     this.sendResponse(true)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -165,6 +165,11 @@ Poltergeist.Browser = (function() {
     }, 5);
   };
 
+  Browser.prototype.clickCoordinates = function(x, y) {
+    this.page.sendEvent('click', x, y);
+    return this.sendResponse(true);
+  };
+
   Browser.prototype.drag = function(page_id, id, other_id) {
     this.node(page_id, id).dragTo(this.node(page_id, other_id));
     return this.sendResponse(true);


### PR DESCRIPTION
First, thanks for poltergeist; it's a huge step up from everything that came before!

So, I recently needed to click a very specific part of the screen to test an interface where one can add markers to an image by clicking on it. After digging around a bit in poltergeist and phantom.js sources, it didn't seem like I could do this without modifying poltergeist directly... not even in a monkeypatch kind of way. Furthermore, it seems like this could be useful for more folks in the future, so Pull Request!

So here's what I added. I'm calling it like so: `page.driver.browser.command 'clickCoordinates', x, y`

I'm guessing this could use some work before its ready to merge, but I figured I'd get the conversation started. What do you think?
