### PR TITLE
Add resize_window alias for compatibility

### DIFF
--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -123,6 +123,7 @@ module Capybara::Poltergeist
     def resize(width, height)
       browser.resize(width, height)
     end
+    alias_method :resize_window, :resize
 
     def network_traffic
       browser.network_traffic


### PR DESCRIPTION
Makes it easier for people porting from capybara-webkit.
