### PR TITLE
Add multiline script evaluation. 

### DIFF
--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -106,7 +106,7 @@ class Poltergeist.Browser
     this.sendResponse this.node(page_id, id).isVisible()
 
   evaluate: (script) ->
-    this.sendResponse @page.evaluate("function() { return #{script} }")
+    this.sendResponse @page.evaluate("function() { return (function(){ return #{script}; }).call(this); }")
 
   execute: (script) ->
     @page.execute("function() { #{script} }")

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -139,7 +139,7 @@ Poltergeist.Browser = (function() {
   };
 
   Browser.prototype.evaluate = function(script) {
-    return this.sendResponse(this.page.evaluate("function() { return " + script + " }"));
+    return this.sendResponse(this.page.evaluate("function() { return (function(){ return " + script + "; }).call(this); }"));
   };
 
   Browser.prototype.execute = function(script) {

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -278,6 +278,16 @@ describe Capybara::Session do
       it "can evaluate a statement ending with a semicolon" do
         @session.evaluate_script("3;").should == 3
       end
+
+      it "can evaluate a multiline script" do
+        @session.evaluate_script(<<-JS).should == [1,2,3]
+          [
+            1,
+            2,
+            3
+          ]
+        JS
+      end
     end
 
     context 'status code support', :status_code_support => true do


### PR DESCRIPTION
Hi!

I've been using multiple line script for `evaluate_script` heavily such as below:

```
display = evaluate_script <<-JS
  $('img.lightbox:first').click();
  document.querySelector('#lightbox-popup').style.display;
JS
display.should == "block"
```

So I need this syntax.
