### PR TITLE
Re-inject agent after a frame load finished

### DIFF
--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -27,6 +27,7 @@ class Poltergeist.Browser
         this.sendResponse(status: status, click: @last_click)
         @state = 'default'
       else if @state == 'awaiting_frame_load'
+        @page.injectAgent()
         this.sendResponse(true)
         @state = 'default'
 

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -40,6 +40,7 @@ Poltergeist.Browser = (function() {
         });
         return _this.state = 'default';
       } else if (_this.state === 'awaiting_frame_load') {
+        _this.page.injectAgent();
         _this.sendResponse(true);
         return _this.state = 'default';
       }

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -349,6 +349,19 @@ describe Capybara::Session do
           @session.body.should include('slow page')
         end
       end
+
+      it 'waits for the cross-domain frame to load' do
+        @session.driver.reset!
+        @session.visit '/poltergeist/frames'
+
+        @session.current_path.should == '/poltergeist/frames'
+
+        @session.within_frame 'frame' do
+          @session.current_path.should == '/poltergeist/iframe'
+        end
+
+        @session.current_path.should == '/poltergeist/frames'
+      end
     end
   end
 end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -38,6 +38,11 @@ class TestApp
     "slow page"
   end
 
+  get '/poltergeist/iframe' do
+    headers['X-Frame-Options'] = nil
+    "iframe"
+  end
+
   get '/poltergeist/:view' do |view|
     render_view view
   end

--- a/spec/support/views/frames.erb
+++ b/spec/support/views/frames.erb
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<iframe name="frame"></iframe>
+</body>
+<script type="text/javascript">
+document.getElementsByName('frame')[0].src = 'http://localhost:' + location.port + '/poltergeist/iframe';
+</script>
+</html>


### PR DESCRIPTION
On some condition, `pushFrame`ed frame is not injected agent.js into and does not have `PoltergeistAgent`, so any commands fails to be called. This PR would fix this problem.

I cannot 100% reproduce this, but switching to a cross-domain frame is likely to cause this problem.

Thanks.
