### PR TITLE
Clearing input before setting a new value

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,11 @@ Include as much information as possible. For example:
 *   Add `page.driver.click(x, y)` to click precise coordinates.
     (Micah Geisel)
 
+#### Bug fixes ####
+
+*   Clearing the value before setting a new value by sending a backspace.
+    This fixes the issue that you can't set an empty value. [Issue #184]
+
 ### 1.0.1 ###
 
 #### Bug fixes ####

--- a/lib/capybara/poltergeist/client/compiled/node.js
+++ b/lib/capybara/poltergeist/client/compiled/node.js
@@ -69,6 +69,7 @@ Poltergeist.Node = (function() {
 
   Node.prototype.set = function(value) {
     this.focusAndHighlight();
+    this.page.sendEvent('keypress', 16777219);
     this.page.sendEvent('keypress', value.toString());
     return this.blur();
   };

--- a/lib/capybara/poltergeist/client/node.coffee
+++ b/lib/capybara/poltergeist/client/node.coffee
@@ -54,5 +54,8 @@ class Poltergeist.Node
 
   set: (value) ->
     this.focusAndHighlight()
+    # Sending backspace to clear the input
+    # keycode from: https://github.com/ariya/phantomjs/commit/cab2635e66d74b7e665c44400b8b20a8f225153a#L0R370
+    @page.sendEvent('keypress', 16777219)
     @page.sendEvent('keypress', value.toString())
     this.blur()

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -120,11 +120,11 @@ describe Capybara::Session do
       end
 
       it 'fires the keydown event' do
-        @session.find(:css, '#changes_on_keydown').text.should == "6"
+        @session.find(:css, '#changes_on_keydown').text.should == "7"
       end
 
       it 'fires the keyup event' do
-        @session.find(:css, '#changes_on_keyup').text.should == "6"
+        @session.find(:css, '#changes_on_keyup').text.should == "7"
       end
 
       it 'fires the keypress event' do
@@ -145,6 +145,12 @@ describe Capybara::Session do
 
       it "fires the keyup event after the value is updated" do
         @session.find(:css, '#value_on_keyup').text.should == "Hello!"
+      end
+      
+      it "clears the input before setting the new value" do
+        element = @session.find(:css, '#change_me')
+        element.set ""
+        element.value.should == ""
       end
     end
 


### PR DESCRIPTION
This commit fixes a bug that you can't set an empty value on an input (or clearing the current input). Like so: `fill_in "field", with: ""`

The fix mimics the user's behavior by sending a backspace key event before setting the new value.

Specs included.
