### PR TITLE
Allow extension JS files to be injected into PhantomJS with the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ end
     as a 2-element array, e.g. [1024, 768]. Default: [1024, 768]
 *   `:phantomjs_options` (Array) - Additional [command line options](https://github.com/ariya/phantomjs/wiki/API-Reference)
     to be passed to PhantomJS, e.g. `['--load-images=no', '--ignore-ssl-errors=yes']`
+*   `:extensions` (Array) - An array of JS files to be preloaded into
+    the phantomjs browser. Useful for faking unsupported APIs.
 *   `:port` (Fixnum) - The port which should be used to communicate
     with the PhantomJS process. Default: 44678.
 
@@ -317,6 +319,11 @@ Include as much information as possible. For example:
     [Issue #192]
 *   Fix `ObsoleteNode` error when using `attach_file` with the `jQuery
     File Upload` plugin. [Issue #115]
+
+*   Add the ability to extend the phantomjs environment via browser
+    options. e.g.
+    `Capybara::Poltergeist::Driver.new( app, :extensions => ['file.js', 'another.js'])`
+    (@JonRowe)
 
 ### 1.0.2 ###
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -168,6 +168,12 @@ module Capybara::Poltergeist
       command 'set_js_errors', !!val
     end
 
+    def extensions=(names)
+      Array(names).each do |name|
+        command 'add_extension', name
+      end
+    end
+
     def command(name, *args)
       message = { 'name' => name, 'args' => args }
       log message.inspect

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -45,6 +45,10 @@ class Poltergeist.Browser
         # window.
         setTimeout((=> this.push_window(name)), 0)
 
+  add_extension: (extension) ->
+    @page.injectExtension extension
+    this.sendResponse 'success'
+
   sendResponse: (response) ->
     errors = @page.errors()
     @page.clearErrors()

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -61,6 +61,11 @@ Poltergeist.Browser = (function() {
     };
   };
 
+  Browser.prototype.add_extension = function(extension) {
+    this.page.injectExtension(extension);
+    return this.sendResponse('success');
+  };
+
   Browser.prototype.sendResponse = function(response) {
     var errors;
     errors = this.page.errors();

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -10,6 +10,8 @@ Poltergeist.WebPage = (function() {
 
   WebPage.COMMANDS = ['currentUrl', 'find', 'nodeCall', 'documentSize', 'beforeUpload', 'afterUpload'];
 
+  WebPage.EXTENSIONS = [];
+
   function WebPage(_native) {
     var callback, _i, _len, _ref;
     this["native"] = _native;
@@ -59,11 +61,24 @@ Poltergeist.WebPage = (function() {
   };
 
   WebPage.prototype.injectAgent = function() {
+    var extension, _k, _len2, _ref2, _results;
     if (this["native"].evaluate(function() {
       return typeof __poltergeist;
     }) === "undefined") {
-      return this["native"].injectJs("" + phantom.libraryPath + "/agent.js");
+      this["native"].injectJs("" + phantom.libraryPath + "/agent.js");
+      _ref2 = WebPage.EXTENSIONS;
+      _results = [];
+      for (_k = 0, _len2 = _ref2.length; _k < _len2; _k++) {
+        extension = _ref2[_k];
+        _results.push(this["native"].injectJs(extension));
+      }
+      return _results;
     }
+  };
+
+  WebPage.prototype.injectExtension = function(file) {
+    WebPage.EXTENSIONS.push(file);
+    return this["native"].injectJs(file);
   };
 
   WebPage.prototype.onConsoleMessageNative = function(message) {

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -7,6 +7,8 @@ class Poltergeist.WebPage
 
   @COMMANDS  = ['currentUrl', 'find', 'nodeCall', 'documentSize', 'beforeUpload', 'afterUpload']
 
+  @EXTENSIONS = []
+
   constructor: (@native) ->
     @native or= require('webpage').create()
 
@@ -35,7 +37,13 @@ class Poltergeist.WebPage
 
   injectAgent: ->
     if @native.evaluate(-> typeof __poltergeist) == "undefined"
-      @native.injectJs("#{phantom.libraryPath}/agent.js")
+      @native.injectJs "#{phantom.libraryPath}/agent.js"
+      for extension in WebPage.EXTENSIONS
+        @native.injectJs extension
+
+  injectExtension: (file) ->
+    WebPage.EXTENSIONS.push file
+    @native.injectJs file
 
   onConsoleMessageNative: (message) ->
     if message == '__DOMContentLoaded'

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -22,7 +22,8 @@ module Capybara::Poltergeist
     def browser
       @browser ||= begin
         browser = Browser.new(server, client, logger)
-        browser.js_errors = options.fetch(:js_errors, true)
+        browser.js_errors  = options.fetch(:js_errors, true)
+        browser.extensions = options.fetch(:extensions,[])
         browser
       end
     end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -188,6 +188,22 @@ module Capybara::Poltergeist
       end
     end
 
+    context 'extending browser javascript' do
+      before do
+        @extended_driver = Capybara::Poltergeist::Driver.new(
+          @driver.app,
+          :logger     => TestSessions.logger,
+          :inspector  => (ENV['DEBUG'] != nil),
+          :extensions => %W% #{File.expand_path '../../support/geolocation.js', __FILE__ } %
+        )
+      end
+
+      it 'supports extending the phantomjs world' do
+        @extended_driver.visit '/'
+        @extended_driver.evaluate_script('navigator.geolocation').should_not eq nil
+      end
+    end
+
     context 'javascript errors' do
       it 'propagates a Javascript error inside Poltergeist to a ruby exception' do
         expect { @driver.browser.command 'browser_error' }.to raise_error(BrowserError)

--- a/spec/support/geolocation.js
+++ b/spec/support/geolocation.js
@@ -1,0 +1,1 @@
+navigator.geolocation = {}


### PR DESCRIPTION
Allow extension JS files to be injected into PhantomJS with the agent.

This allows things like geolocation and other APIs to be faked out before the page loads.

(I'm using this to test a phonegap application so being able to inject before the page loads to simulate phonegap is important to me)
