### PR TITLE
Add Capybara 2.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /ci/Gemfile.*.lock
 /spec/tmp
 /rspec.failures
+/vendor
+/.bundle

--- a/README.md
+++ b/README.md
@@ -24,20 +24,21 @@ detail](https://github.com/jnicklas/capybara/blob/master/README.md#transactions-
 
 ## Installing PhantomJS ##
 
-You need at least PhantomJS 1.7.0.  There are *no other external
+You need at least PhantomJS 1.8.1.  There are *no other external
 dependencies* (you don't need Qt, or a running X server, etc.)
 
 ### Mac ###
 
 * *Homebrew*: `brew install phantomjs`
-* *Manual install*: [Download this](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.7.0-macosx.zip&can=2&q=)
+* *MacPorts*: `sudo port install phantomjs`
+* *Manual install*: [Download this](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.8.1-macosx.zip&can=2&q=)
 
 ### Linux ###
 
 * Download the [32
-bit](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.7.0-linux-i686.tar.bz2&can=2&q=)
+bit](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.8.1-linux-i686.tar.bz2&can=2&q=)
 or [64
-bit](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.7.0-linux-x86_64.tar.bz2&can=2&q=)
+bit](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.8.1-linux-x86_64.tar.bz2&can=2&q=)
 binary.
 * Extract the tarball and copy `bin/phantomjs` into your `PATH`
 
@@ -46,7 +47,7 @@ binary.
 Do this as a last resort if the binaries don't work for you. It will
 take quite a long time as it has to build WebKit.
 
-* Download [the source tarball](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.7.0-source.zip&can=2&q=)
+* Download [the source tarball](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.8.1-source.zip&can=2&q=)
 * Extract and cd in
 * `./build.sh`
 
@@ -175,8 +176,7 @@ end
 *   `:debug` (Boolean) - When true, debug output is logged to `STDERR`
 *   `:logger` (Object responding to `puts`) - When present, debug output is written to this object
 *   `:timeout` (Numeric) - The number of seconds we'll wait for a response
-    when communicating with PhantomJS. `nil` means wait forever. Default
-    is 30.
+    when communicating with PhantomJS. Default is 30.
 *   `:inspector` (Boolean, String) - See 'Remote Debugging', above.
 *   `:js_errors` (Boolean) - When false, Javascript errors do not get re-raised in Ruby.
 *   `:window_size` (Array) - The dimensions of the browser window in which to test, expressed
@@ -324,10 +324,13 @@ Include as much information as possible. For example:
 
 ### Next release ###
 
+#### Bug fixes ####
+
 #### Features ####
 
 *   Add `page.driver.click(x, y)` to click precise coordinates.
     (Micah Geisel)
+*   Add Capybara 2.0 support. (Mauro Asprea) [Issue #163]
 
 ### 1.0.2 ###
 

--- a/ci/install_phantomjs
+++ b/ci/install_phantomjs
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=phantomjs-1.7.0-linux-i686
+version=phantomjs-1.8.1-linux-i686
 wget http://phantomjs.googlecode.com/files/$version.tar.bz2
 tar xjf $version.tar.bz2
 mv $version phantomjs

--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -1,7 +1,7 @@
 module Capybara::Poltergeist
   class Client
     PHANTOMJS_SCRIPT  = File.expand_path('../client/compiled/main.js', __FILE__)
-    PHANTOMJS_VERSION = '1.7.0'
+    PHANTOMJS_VERSION = '1.8.1'
     PHANTOMJS_NAME    = 'phantomjs'
 
     def self.start(*args)

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -4,7 +4,7 @@ module Capybara::Poltergeist
   class Driver < Capybara::Driver::Base
     DEFAULT_TIMEOUT = 30
 
-    attr_reader :app, :app_server, :server, :client, :browser, :options
+    attr_reader :app, :server, :client, :browser, :options
 
     def initialize(app, options = {})
       @app       = app
@@ -13,9 +13,10 @@ module Capybara::Poltergeist
       @inspector = nil
       @server    = nil
       @client    = nil
+    end
 
-      @app_server = Capybara::Server.new(app)
-      @app_server.boot if Capybara.run_server
+    def needs_server?
+      true
     end
 
     def browser
@@ -77,8 +78,8 @@ module Capybara::Poltergeist
       options.fetch(:js_errors, true)
     end
 
-    def visit(path)
-      browser.visit app_server.url(path)
+    def visit(url)
+      browser.visit(url)
     end
 
     def current_url
@@ -89,9 +90,10 @@ module Capybara::Poltergeist
       browser.status_code
     end
 
-    def body
+    def html
       browser.body
     end
+    alias_method :body, :html
 
     def source
       browser.source.to_s
@@ -126,9 +128,10 @@ module Capybara::Poltergeist
       browser.reset
     end
 
-    def render(path, options = {})
+    def save_screenshot(path, options = {})
       browser.render(path, options)
     end
+    alias_method :render, :save_screenshot
 
     def resize(width, height)
       browser.resize(width, height)
@@ -155,7 +158,7 @@ module Capybara::Poltergeist
       browser.set_cookie({
         :name   => name,
         :value  => value,
-        :domain => URI.parse(app_server.url('')).host
+        :domain => URI.parse(browser.current_url).host
       }.merge(options))
     end
 

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -1,5 +1,8 @@
 module Capybara::Poltergeist
   class Node < Capybara::Driver::Node
+    NBSP = "\xC2\xA0"
+    NBSP.force_encoding("UTF-8") if NBSP.respond_to?(:force_encoding)
+
     attr_reader :page_id, :id
 
     def initialize(driver, page_id, id)
@@ -31,7 +34,7 @@ module Capybara::Poltergeist
     end
 
     def text
-      command(:text).strip.gsub(/\s+/, ' ')
+      command(:text).gsub(NBSP, ' ').gsub(/\s+/u, ' ').strip
     end
 
     def [](name)

--- a/poltergeist.gemspec
+++ b/poltergeist.gemspec
@@ -14,13 +14,13 @@ Gem::Specification.new do |s|
   s.summary     = "PhantomJS driver for Capybara"
   s.description = "PhantomJS driver for Capybara"
 
-  s.add_dependency "capybara",       "~> 1.1"
+  s.add_dependency "capybara",       "~> 2.0", ">= 2.0.1"
   s.add_dependency "multi_json",     "~> 1.0"
   s.add_dependency "childprocess",   "~> 0.3"
   s.add_dependency "http_parser.rb", "~> 0.5.3"
   s.add_dependency "faye-websocket", "~> 0.4", ">= 0.4.4"
 
-  s.add_development_dependency 'rspec',              '~> 2.8'
+  s.add_development_dependency 'rspec',              '~> 2.12'
   s.add_development_dependency 'sinatra',            '~> 1.0'
   s.add_development_dependency 'rake',               '~> 0.9.2'
   s.add_development_dependency 'image_size',         '~> 1.0'

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -1,16 +1,12 @@
 require 'spec_helper'
-require 'capybara/spec/session'
+
+Capybara::SpecHelper.run_specs TestSessions::Poltergeist, "Poltergeist"
 
 describe Capybara::Session do
   context 'with poltergeist driver' do
     before do
       @session = TestSessions::Poltergeist
     end
-
-    it_should_behave_like "session"
-    it_should_behave_like "session with javascript support"
-    it_should_behave_like "session with headers support"
-    it_should_behave_like "session with status code support"
 
     describe Capybara::Poltergeist::Node do
       it 'raises an error if the element has been removed from the DOM' do
@@ -146,7 +142,7 @@ describe Capybara::Session do
       it "fires the keyup event after the value is updated" do
         @session.find(:css, '#value_on_keyup').text.should == "Hello!"
       end
-      
+
       it "clears the input before setting the new value" do
         element = @session.find(:css, '#change_me')
         element.set ""
@@ -199,7 +195,7 @@ describe Capybara::Session do
       @session.visit '/poltergeist/index'
       @session.click_link "JS redirect"
       sleep 0.1
-      @session.body.should include("Hello world")
+      @session.html.should include("Hello world")
     end
 
     context 'click tests' do
@@ -335,7 +331,7 @@ describe Capybara::Session do
         CODE
 
         @session.within_window 'popup' do
-          @session.body.should include('slow page')
+          @session.html.should include('slow page')
         end
       end
     end
@@ -352,7 +348,7 @@ describe Capybara::Session do
 
         @session.within_frame 'frame' do
           @session.current_path.should == "/poltergeist/slow"
-          @session.body.should include('slow page')
+          @session.html.should include('slow page')
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,11 @@ $:.unshift(POLTERGEIST_ROOT + '/lib')
 require 'bundler/setup'
 
 require 'rspec'
+require 'capybara/spec/spec_helper'
 require 'capybara/poltergeist'
 
 require 'support/test_app'
 require 'support/spec_logger'
-
-Capybara.default_wait_time = 0 # less timeout so tests run faster
 
 alias :running :lambda
 
@@ -32,12 +31,6 @@ end
 
 RSpec.configure do |config|
   config.before do
-    Capybara.configure do |config|
-      config.default_selector = :xpath
-    end
-  end
-
-  config.before do
     TestSessions.logger.reset
   end
 
@@ -48,4 +41,15 @@ RSpec.configure do |config|
       example.exception.message << "\n\nDebug info:\n" + TestSessions.logger.messages.join("\n")
     end
   end
+
+  Capybara::SpecHelper.configure(config)
+
+  config.before(:each) do
+    Capybara.default_wait_time = 0
+  end
+
+  config.before(:each, :requires => :js) do
+    Capybara.default_wait_time = 1
+  end
+
 end


### PR DESCRIPTION
See: #136 Capybara 2.0 support

Things changed:
- Server#url is no more. It's a Session responsibility and happens transparently from the Driver's point of view.
- Session is responsible for starting the server
- Use Capybara::SpecHelper.run_specs to run validate all specs with the driver
- render is now save_screenshot  (for a failing spec)
- set_cookie needed a domain in specs eg: `:domain => '127.0.0.1'`  (for a failing spec)
- Normalized whitespace stripping much like capybara-webkit is doing (for a failing spec)

All but one capybara's spec are passing: 
- HTML5 Multiple File Upload: This is from the capybara specs and also didn't found proper documentation in phantomjs that would lead me into having this fixed...

@jonleighton I'm calling for help here to fix multiple file uploads
