### PR TITLE
Ensure value (file path) is a String when using #set on an input node

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,11 +325,13 @@ Include as much information as possible. For example:
     [Issue #192]
 *   Fix `ObsoleteNode` error when using `attach_file` with the `jQuery
     File Upload` plugin. [Issue #115]
-
 *   Add the ability to extend the phantomjs environment via browser
     options. e.g.
     `Capybara::Poltergeist::Driver.new( app, :extensions => ['file.js', 'another.js'])`
     (@JonRowe)
+*   Ensure that a `String` is passed over-the-wire to PhantomJS for
+    file input paths, allowing `attach_file` to be called with arbitry
+    objects such as a Pathname. (@mjtko) [Issue #215]
 
 ### 1.0.2 ###
 

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -53,7 +53,7 @@ module Capybara::Poltergeist
         when 'checkbox'
           click if value != checked?
         when 'file'
-          command :select_file, value
+          command :select_file, value.to_s
         else
           command :set, value.to_s
         end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -154,6 +154,12 @@ describe Capybara::Session do
         element.set "$52.00"
         element.value.should == "$52.00"
       end
+
+      it 'attaches a file when passed a Pathname' do
+        element = @session.find(:css, '#change_me_file')
+        element.set Pathname.new("a_test_pathname")
+        element.value.should == 'C:\fakepath\a_test_pathname'
+      end
     end
 
     it 'has no trouble clicking elements when the size of a document changes' do

--- a/spec/support/views/with_js.erb
+++ b/spec/support/views/with_js.erb
@@ -36,6 +36,7 @@
       <label for="change_me_withname">Change me</label>
       <input type="text" name="change_me_withname" id="change_me_withname">
     </p>
+    <p><input type="file" name="change_me_file" id="change_me_file"></p>
     <p id="changes"></p>
     <p id="changes_on_input"></p>
     <p id="changes_on_keydown"></p>


### PR DESCRIPTION
This patch ensures that a String is passed over-the-wire to PhantomJS for file input paths rather than an arbitrary object.

I came across this issue when using Capybara's `#attach_file` - I happened to be using a `Pathname` object (I use `Rails.root.join` to generate a path to a fixture file) which caused the client to receive a malformed object for the file upload.

This brings Poltergeist into line with Capybara's Selenium implementation which does this, and restores the principle of least surprise! :wink:

``` ruby
  elsif tag_name == 'input' and type == 'file'
      resynchronize do
        native.send_keys(value.to_s)
      end
```
