### PR TITLE
Add support for a custom PhantomJS logger 

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ end
 *   `:phantomjs` (String) - A custom path to the phantomjs executable
 *   `:debug` (Boolean) - When true, debug output is logged to `STDERR`
 *   `:logger` (Object responding to `puts`) - When present, debug output is written to this object
+*   `:phantomjs_logger` (Object behaving like `IO`) - When present, the `STDOUT` of phantomjs is redirected to this object
 *   `:timeout` (Numeric) - The number of seconds we'll wait for a response
     when communicating with PhantomJS. Default is 30.
 *   `:inspector` (Boolean, String) - See 'Remote Debugging', above.
@@ -291,7 +292,9 @@ Include as much information as possible. For example:
 ### Next release ###
 
 #### Features ####
-
+    
+*   Add support for custom phantomjs loggers via `:phantomjs_logger` option.
+    (Gabe Bell)    
 *   Add `page.driver.click(x, y)` to click precise coordinates.
     (Micah Geisel)
 *   Add Capybara 2.0 support. Capybara 1.1 and Ruby 1.8 are *no

--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -21,6 +21,7 @@ module Capybara::Poltergeist
       @path              = options[:path]              || PHANTOMJS_NAME
       @window_size       = options[:window_size]       || [1024, 768]
       @phantomjs_options = options[:phantomjs_options] || []
+      @phantomjs_logger  = options[:phantomjs_logger]  || $stdout
 
       pid = Process.pid
       at_exit { stop if Process.pid == pid }
@@ -28,7 +29,7 @@ module Capybara::Poltergeist
 
     def start
       check_phantomjs_version
-      @pid = Process.spawn(*command.map(&:to_s))
+      @pid = Process.spawn(*command.map(&:to_s), out: @phantomjs_logger)
     end
 
     def stop

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -42,7 +42,8 @@ module Capybara::Poltergeist
       @client ||= Client.start(server.port,
         :path              => options[:phantomjs],
         :window_size       => options[:window_size],
-        :phantomjs_options => phantomjs_options
+        :phantomjs_options => phantomjs_options,
+        :phantomjs_logger  => phantomjs_logger
       )
     end
 
@@ -76,6 +77,11 @@ module Capybara::Poltergeist
     # logger should be an object that responds to puts, or nil
     def logger
       options[:logger] || (options[:debug] && STDERR)
+    end
+
+    # logger should be an object that behaves like IO or nil
+    def phantomjs_logger
+      options.fetch(:phantomjs_logger, nil)
     end
 
     def visit(url)

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -41,6 +41,18 @@ module Capybara::Poltergeist
         driver.quit if driver
       end
     end
+    
+    it 'supports capturing console.log' do
+      IO.pipe do |read_io, write_io|
+        Capybara.register_driver :poltergeist_with_logger do |app|
+          Capybara::Poltergeist::Driver.new(app, {:phantomjs_logger => write_io})
+        end
+        
+        session = Capybara::Session.new(:poltergeist_with_logger, TestApp)
+        session.visit('/poltergeist/console_log')
+        read_io.gets.to_s.should include('Hello world')
+      end
+    end
 
     it 'raises an error and restart the client, if the client dies while executing a command' do
       lambda { @driver.browser.command('exit') }.should raise_error(DeadClient)

--- a/spec/support/views/console_log.erb
+++ b/spec/support/views/console_log.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="text/javascript">
+  window.onload = function() {
+    console.log("Hello world");
+  }
+  </script>
+</head>
+<body>
+</body>
+</html>

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -31,20 +31,29 @@ module Capybara::Poltergeist
       end
     end
 
-    context "with width and height specified" do
+    context 'with width and height specified' do
       subject { Client.new(6000, :window_size => [800, 600]) }
 
-      it "starts phantomjs, passing the width and height through" do
-        Process.should_receive(:spawn).with("phantomjs", Client::PHANTOMJS_SCRIPT, "6000", "800", "600")
+      it 'starts phantomjs, passing the width and height through' do
+        Process.should_receive(:spawn).with("phantomjs", Client::PHANTOMJS_SCRIPT, "6000", "800", "600", out: $stdout)
+        subject.start
+      end
+    end
+    
+    context 'with a custom phantomjs_logger' do
+      subject { Client.new(6000, :phantomjs_logger => :my_custom_logger, :window_size => [800, 600]) }
+
+      it 'starts phantomjs, capturing the STDOUT to custom phantomjs_logger' do
+        Process.should_receive(:spawn).with("phantomjs", Client::PHANTOMJS_SCRIPT, "6000", "800", "600", out: :my_custom_logger)
         subject.start
       end
     end
 
-    context "with additional command-line options" do
+    context 'with additional command-line options' do
       subject { Client.new(6000, :phantomjs_options => %w[--ignore-ssl-error=yes --load-images=no]) }
 
       it 'passed additional command-line options to phantomjs' do
-        Process.should_receive(:spawn).with("phantomjs", '--ignore-ssl-error=yes', '--load-images=no', anything, anything, anything, anything)
+        Process.should_receive(:spawn).with("phantomjs", '--ignore-ssl-error=yes', '--load-images=no', anything, anything, anything, anything, out: $stdout)
         subject.start
       end
     end

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -21,6 +21,14 @@ module Capybara::Poltergeist
         subject.logger.should == :my_custom_logger
       end
     end
+    
+    context 'with a :phantomjs_logger option' do
+      subject { Driver.new(nil, :phantomjs_logger => :my_custom_logger) }
+
+      it 'logs to the phantomjs_logger given' do
+        subject.phantomjs_logger.should == :my_custom_logger
+      end
+    end
 
     context 'with a :debug => true option' do
       subject { Driver.new(nil, :debug => true) }


### PR DESCRIPTION
Related to this issue: https://github.com/jonleighton/poltergeist/issues/94

Allows the user to specify a IO object for the output of PhantomJS. This allows the testing, capturing and silencing of the output. 
- supports any `IO` compatible object
- defaults to `$stdout`
- specified via `:phantomjs_logger` in `Driver.new`
