### PR TITLE
Implemented fixes for Poltergeist on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ bit](http://code.google.com/p/phantomjs/downloads/detail?name=phantomjs-1.8.1-li
 binary.
 * Extract the tarball and copy `bin/phantomjs` into your `PATH`
 
+### Windows ###
+* Download the [precompiled binary](http://phantomjs.org/download.html) for Windows
+
 ### Manual compilation ###
 
 Do this as a last resort if the binaries don't work for you. It will
@@ -68,12 +71,12 @@ guide](http://phantomjs.org/build.html).)
 
 ## Compatibility ##
 
-Poltergeist runs on MRI 1.9, JRuby 1.9 and Rubinius 1.9.
+Poltergeist runs on MRI 1.9, JRuby 1.9 and Rubinius 1.9. Poltergeist
+and PhantomJS are currently supported on Mac OS X, Linux, and Windows
+platforms.
 
 Ruby 1.8 is no longer supported. The last release to support Ruby 1.8
 was 1.0.2, so you should use that if you still need Ruby 1.8 support.
-
-Poltergeist does not currently support the Windows operating system.
 
 ## Running on a CI ##
 
@@ -313,6 +316,7 @@ Include as much information as possible. For example:
 
 #### Features ####
 
+*   Support for Windows hosted Poltergeist (Aaron Tull).
 *   Add support for custom phantomjs loggers via `:phantomjs_logger` option.
     (Gabe Bell)
 *   Add `page.driver.click(x, y)` to click precise coordinates.

--- a/lib/capybara/poltergeist.rb
+++ b/lib/capybara/poltergeist.rb
@@ -7,6 +7,7 @@ require 'capybara'
 
 module Capybara
   module Poltergeist
+    require 'capybara/poltergeist/utility'
     require 'capybara/poltergeist/driver'
     require 'capybara/poltergeist/browser'
     require 'capybara/poltergeist/node'

--- a/lib/capybara/poltergeist/utility.rb
+++ b/lib/capybara/poltergeist/utility.rb
@@ -1,0 +1,9 @@
+module Capybara
+  module Poltergeist
+    class << self
+      def windows?
+        RbConfig::CONFIG["host_os"] =~ /mingw|mswin|cygwin/
+      end
+    end
+  end
+end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -84,7 +84,7 @@ module Capybara::Poltergeist
           )
         end
         driver = Capybara::Session.new(:poltergeist_with_custom_window_size, TestApp).driver
-        driver.visit("/")
+        driver.visit(session_url '/')
         driver.evaluate_script('[window.innerWidth, window.innerHeight]').should eq([800, 600])
       ensure
         driver.quit if driver
@@ -191,11 +191,19 @@ module Capybara::Poltergeist
       driver = Capybara::Poltergeist::Driver.new(nil)
       pid    = driver.client_pid
 
-      Process.kill(0, pid).should == 1
+      def terminate_process(pid)
+        if Capybara::Poltergeist.windows?
+          Process.kill('KILL', pid).should == 1
+        else
+          Process.kill('EXIT', pid).should == 1
+        end
+      end
+
+      terminate_process(pid)
       driver.quit
 
       begin
-        Process.kill(0, pid)
+        terminate_process(pid)
       rescue Errno::ESRCH
       else
         raise "process is still alive"

--- a/spec/support/custom_phantomjs.bat
+++ b/spec/support/custom_phantomjs.bat
@@ -1,0 +1,2 @@
+@echo off > "%0%\..\custom_phantomjs_called"
+phantomjs.exe %1


### PR DESCRIPTION
- TCPServer requires a host in a Windows environment (see util.rb).
- Killing PhantomJS process does not respond to TERM (client.rb).
- Integration spec tried to run a bash file. Added bat file
  (driver_spec.rb).
- Improved algorithm to check phantomjs version.
