### PR TITLE
return nil if no expires on cookie (fixes #203)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ Include as much information as possible. For example:
     after the block has executed. [Issue #242]
 *   Fix calculation of click position when clicking within a frame.
     [Issue #222, #225]
+*   Fix error raising when calling `expires` if not set on cookie.
+    [Issue #203] (@arnvald)
 
 ### 1.0.2 ###
 

--- a/lib/capybara/poltergeist/cookie.rb
+++ b/lib/capybara/poltergeist/cookie.rb
@@ -29,6 +29,7 @@ module Capybara::Poltergeist
     end
 
     def expires
+      return nil unless @attributes['expires']
       Time.parse @attributes['expires']
     end
   end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -325,6 +325,7 @@ module Capybara::Poltergeist
         cookie.path.should      == '/'
         cookie.secure?.should   == false
         cookie.httponly?.should == false
+        cookie.expires.should   == nil
       end
 
       it 'can set cookies' do


### PR DESCRIPTION
Hey,

not sure if I updated correct place in changelog (my first contribution).
This fixes https://github.com/jonleighton/poltergeist/issues/203
When `expires` is not set on cookie and it is called, currently error appears. This fix returns nil instead.
