### PR TITLE
Drag & Drop a Node by Pixels

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -111,6 +111,16 @@ module Capybara::Poltergeist
       command 'drag', page_id, id, other_id
     end
 
+    def drag_by(page_id, id, dimensions)
+      left, right = dimensions.fetch(:left, 0), dimensions.fetch(:right, 0)
+      up, down = dimensions.fetch(:up, 0), dimensions.fetch(:down, 0)
+
+      x_delta = right - left
+      y_delta = down - up
+
+      command 'drag_by', page_id, id, x_delta, y_delta
+    end
+
     def select(page_id, id, value)
       command 'select', page_id, id, value
     end

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -197,6 +197,10 @@ class Poltergeist.Browser
     this.node(page_id, id).dragTo this.node(page_id, other_id)
     this.sendResponse(true)
 
+  drag_by: (page_id, id, xDelta, yDelta) ->
+    this.node(page_id, id).dragBy(xDelta, yDelta)
+    this.sendResponse(true)
+
   trigger: (page_id, id, event) ->
     this.node(page_id, id).trigger(event)
     this.sendResponse(event)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -256,6 +256,11 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(true);
   };
 
+  Browser.prototype.drag_by = function(page_id, id, right, down) {
+    this.node(page_id, id).dragBy(right, down);
+    return this.sendResponse(true);
+  };
+
   Browser.prototype.trigger = function(page_id, id, event) {
     this.node(page_id, id).trigger(event);
     return this.sendResponse(event);

--- a/lib/capybara/poltergeist/client/compiled/node.js
+++ b/lib/capybara/poltergeist/client/compiled/node.js
@@ -66,6 +66,18 @@ Poltergeist.Node = (function() {
     return this.page.mouseEvent('mouseup', otherPosition.x, otherPosition.y);
   };
 
+  Node.prototype.dragBy = function(xDelta, yDelta) {
+    var newPosition, position;
+    this.scrollIntoView();
+    position = this.clickPosition();
+    newPosition = {
+      x: position.x + xDelta,
+      y: position.y + yDelta
+    };
+    this.page.mouseEvent('mousedown', position.x, position.y);
+    return this.page.mouseEvent('mouseup', newPosition.x, newPosition.y);
+  };
+
   Node.prototype.isEqual = function(other) {
     return this.page === other.page && this.isDOMEqual(other.id);
   };

--- a/lib/capybara/poltergeist/client/node.coffee
+++ b/lib/capybara/poltergeist/client/node.coffee
@@ -49,6 +49,18 @@ class Poltergeist.Node
     @page.mouseEvent('mousedown', position.x,      position.y)
     @page.mouseEvent('mouseup',   otherPosition.x, otherPosition.y)
 
+  dragBy: (xDelta, yDelta) ->
+    this.scrollIntoView()
+
+    position = this.clickPosition()
+    newPosition = {
+      x: position.x + xDelta,
+      y: position.y + yDelta,
+    }
+
+    @page.mouseEvent('mousedown', position.x, position.y)
+    @page.mouseEvent('mouseup', newPosition.x, newPosition.y)
+
   isEqual: (other) ->
     @page == other.page && this.isDOMEqual(other.id)
 

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -100,6 +100,10 @@ module Capybara::Poltergeist
       command :drag, other.id
     end
 
+    def drag_by(dimensions)
+      command :drag_by, dimensions
+    end
+
     def trigger(event)
       command :trigger, event
     end


### PR DESCRIPTION
I've added an implementation to allow dragging of elements by pixel amounts. The impetus behind this was switching an application from Selenium to Poltergeist and it had a [custom extension](http://stackoverflow.com/a/10868865/818057) for doing this in Selenium.

I've implemented a similar API for Poltergeist, using this application extension:

```
module CapybaraExtension
  def drag_by(dimensions)
    base.drag_by(dimensions)
  end
end

::Capybara::Node::Element.send(:include, CapybaraExtension)
```

the API looks like this:

```
find('.ui-slider-handle').drag_by(left: 100)
```

It supports the following options: `:up`, `:down`, `:left`, `:down`.

---

Is this something you would consider adding to Poltergeist? If you did I think a patch to Capybara would probably get accepted because it can currently be implemented in Selenium.

Have you got any comments on the API? I don't think `drag_by` is a great name, I think `drag` would be better name. What do you think about overloading the current method?

---

I've tested this branch on an application and it works. I haven't included any specs yet. I assume these would belong in `session_spec.rb`. Also what is the policy on documentation?
