### PR TITLE
Inject Agent and Page Extensions on native initialisation

### DIFF
--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -54,6 +54,7 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.onInitializedNative = function() {
     this._source = null;
+    this.injectAgent();
     return this.setScrollPosition({
       left: 0,
       top: 0

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -33,6 +33,7 @@ class Poltergeist.WebPage
 
   onInitializedNative: ->
     @_source = null
+    @injectAgent()
     this.setScrollPosition(left: 0, top: 0)
 
   injectAgent: ->

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -201,7 +201,7 @@ module Capybara::Poltergeist
     context 'extending browser javascript' do
       before do
         @extended_driver = Capybara::Poltergeist::Driver.new(
-          @driver.app,
+          @session.app,
           :logger     => TestSessions.logger,
           :inspector  => (ENV['DEBUG'] != nil),
           :extensions => %W% #{File.expand_path '../../support/geolocation.js', __FILE__ } %
@@ -209,7 +209,9 @@ module Capybara::Poltergeist
       end
 
       it 'supports extending the phantomjs world' do
-        @extended_driver.visit '/'
+        @extended_driver.visit session_url("/poltergeist/requiring_custom_extension")
+        @extended_driver.body.should include(%Q%Location: <span id="location">1,-1</span>%)
+        @extended_driver.evaluate_script("document.getElementById('location').innerHTML").should == '1,-1'
         @extended_driver.evaluate_script('navigator.geolocation').should_not eq nil
       end
     end

--- a/spec/support/geolocation.js
+++ b/spec/support/geolocation.js
@@ -1,1 +1,7 @@
-navigator.geolocation = {}
+navigator.geolocation =
+  {
+    getCurrentPosition: function(callback)
+    {
+      callback({ coords: { latitude: '1', longitude: '-1' } });
+    }
+  }

--- a/spec/support/views/requiring_custom_extension.erb
+++ b/spec/support/views/requiring_custom_extension.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+  <p>Location: <span id='location'></span></p>
+  <script type="text/javascript">
+    navigator.geolocation.getCurrentPosition(function(position)
+    {
+      document.getElementById('location').innerHTML = position.coords.latitude+','+position.coords.longitude;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Extensions need to be loaded before the page fires off it's own scripts, previously there was a call to injectAgent upon page initialisation, this seems to have been made lazy at some point. This reverts that change and thus makes extensions and the poltergeist agent available before the page runs it's own scripts...

I updated the integration test to prove this behaviour, squashed commits and also updated changes to fix some typo's from last time and added the new bug fix.
