### PR TITLE
Add test for windows opened by the "target" attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,14 @@ Include as much information as possible. For example:
 
 ## Changes ##
 
+### 1.1.x ###
+
+#### Features ####
+
+*   Windows opened by the `target` attribute of a link are identified by the 
+    handle `""`.  
+    _e.g._ `within_window("") { ... }` (Cameron Walters)
+
 ### 1.1.0 ###
 
 #### Features ####

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -363,6 +363,14 @@ describe Capybara::Session do
           @session.html.should include('slow page')
         end
       end
+
+      it 'can identify a new window opened via the target attribute (no name)' do
+        @session.visit '/poltergeist/target'
+        @session.click_link 'Link'
+        @session.within_window '' do
+          @session.html.should include('slow page')
+        end
+      end
     end
 
     context 'frame support' do

--- a/spec/support/views/target.erb
+++ b/spec/support/views/target.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test</title>
+  </head>
+
+  <body>
+    <a href="/poltergeist/slow" target="_blank">Link</a>
+
+    <p id="break">Foo<br>Bar</p>
+  </body>
+</html>


### PR DESCRIPTION
These windows have a handle of "" (the empty string).

It might be nice in the future to name these windows after the value of the target attribute, though that would be a breaking change.
