### PR TITLE
Clarify how to enable the debug mode in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ When this option is enabled, you can insert `page.driver.debug` into
 your tests to pause the test and launch a browser which gives you the
 WebKit inspector to view your test run with.
 
-You can register this debugger driver with a different name and set it 
-as the current javascript driver. By example, in your herlper file:
+You can register this debugger driver with a different name and set it
+as the current javascript driver. By example, in your helper file:
 
 ```ruby
 Capybara.register_driver :poltergeist_debug do |app|


### PR DESCRIPTION
I would like to clarify how to enable the debug mode.
At first I was adding a :inspector => true meta tag to my examples.
I've found the answer in this issue
https://github.com/jonleighton/poltergeist/issues/47

At least one more person made the same mistake, so maybe its useful.
