### PR TITLE
Remove PhantomJS, installed by default on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-before_script:
-  - sudo ci/install_phantomjs
-  - "export PATH=phantomjs/bin:$PATH"
-  - phantomjs --version
 script: bundle exec rake ci
 rvm:
   - 2.0.0


### PR DESCRIPTION
I talked to @joshk today since our Poltergeist tests were passing on Travis without this stuff in our travis.yml and he said PhantomJS is now installed by default on Travis, so you shouldn't need this.
