### PR TITLE
Specify dependencies by using ~>

### DIFF
--- a/poltergeist.gemspec
+++ b/poltergeist.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.2"
 
-  s.add_dependency "capybara",       "~> 2.0", ">= 2.0.1"
+  s.add_dependency "capybara",       "~> 2.0.1"
   s.add_dependency "http_parser.rb", "~> 0.5.3"
-  s.add_dependency "faye-websocket", "~> 0.4", ">= 0.4.4"
+  s.add_dependency "faye-websocket", "~> 0.4.4"
 
   s.add_development_dependency 'rspec',              '~> 2.12'
   s.add_development_dependency 'sinatra',            '~> 1.0'


### PR DESCRIPTION
This is intended to help people who update their gems and find specs 
broken, since poltergeist 1.1 is not compatible with capybara 2.1

This change fixes the capybara dependency to a 2.0.x version.
