### PR TITLE
Driver can enable or disable PhantomJS cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ Include as much information as possible. For example:
 
 ### Next release ###
 
+#### Features ####
+*   Add support for PhantomJS 1.7's `cookiesEnabled` API
+    (Micah Frost)
+
 #### Bug fixes ####
 
 *   Fix logging of mouse event co-ordinates

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -197,6 +197,10 @@ module Capybara::Poltergeist
       command 'remove_cookie', name
     end
 
+    def cookies_enabled=(flag)
+      command 'cookies_enabled', !!flag
+    end
+
     def js_errors=(val)
       command 'set_js_errors', !!val
     end

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -285,6 +285,10 @@ class Poltergeist.Browser
     @page.deleteCookie(name)
     this.sendResponse(true)
 
+  cookies_enabled: (flag) ->
+    phantom.cookiesEnabled = flag
+    this.sendResponse(true)
+
   set_js_errors: (value) ->
     @js_errors = value
     this.sendResponse(true)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -393,6 +393,11 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(true);
   };
 
+  Browser.prototype.cookies_enabled = function(flag) {
+    phantom.cookiesEnabled = flag;
+    return this.sendResponse(true);
+  };
+
   Browser.prototype.set_js_errors = function(value) {
     this.js_errors = value;
     return this.sendResponse(true);

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -191,6 +191,10 @@ module Capybara::Poltergeist
       browser.remove_cookie(name)
     end
 
+    def cookies_enabled=(flag)
+      browser.cookies_enabled = flag
+    end
+
     def debug
       if @options[:inspector]
         inspector.open

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -405,6 +405,16 @@ module Capybara::Poltergeist
         @driver.set_cookie 'foo', 'bar', :expires => time
         @driver.cookies['foo'].expires.should == time
       end
+
+      it 'can enable and disable cookies' do
+        @driver.cookies_enabled = false
+        @session.visit('/set_cookie')
+        @driver.cookies.should be_empty
+
+        @driver.cookies_enabled = true
+        @session.visit('/set_cookie')
+        @driver.cookies.should_not be_empty
+      end
     end
 
     it "allows the driver to have a fixed port" do


### PR DESCRIPTION
As of 1.7, PhantomJS allows its `CookieJar` to be enabled or disabled using the `cookiesEnabled` function. This commit adds access to that from the driver using a similarly named `cookies_enabled=` method.

For more information on the API, check out:

https://github.com/ariya/phantomjs/wiki/API-Reference-phantom#cookiesenabled-boolean
