### PR TITLE
Fix within_window finding window after close/open

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ Include as much information as possible. For example:
 #### Features ####
 *   Add support for PhantomJS 1.7's `cookiesEnabled` API
     (Micah Frost)
+*   Fix within_window finding window after close/open
+    (Ryan Schlesinger) [Issue #312]
 
 #### Bug fixes ####
 

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -21,7 +21,6 @@ Poltergeist.WebPage = (function() {
     this._errors = [];
     this._networkTraffic = {};
     this.frames = [];
-    this.sub_pages = {};
     _ref = WebPage.CALLBACKS;
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       callback = _ref[_i];
@@ -244,13 +243,9 @@ Poltergeist.WebPage = (function() {
   WebPage.prototype.getPage = function(name) {
     var page;
 
-    if (this.sub_pages[name]) {
-      return this.sub_pages[name];
-    } else {
-      page = this["native"].getPage(name);
-      if (page) {
-        return this.sub_pages[name] = new Poltergeist.WebPage(page);
-      }
+    page = this["native"].getPage(name);
+    if (page) {
+      return new Poltergeist.WebPage(page);
     }
   };
 

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -16,7 +16,6 @@ class Poltergeist.WebPage
     @_errors         = []
     @_networkTraffic = {}
     @frames          = []
-    @sub_pages       = {}
 
     for callback in WebPage.CALLBACKS
       this.bindCallback(callback)
@@ -161,11 +160,8 @@ class Poltergeist.WebPage
     @native.switchToParentFrame()
 
   getPage: (name) ->
-    if @sub_pages[name]
-      @sub_pages[name]
-    else
-      page = @native.getPage(name)
-      @sub_pages[name] = new Poltergeist.WebPage(page) if page
+    page = @native.getPage(name)
+    new Poltergeist.WebPage(page) if page
 
   dimensions: ->
     scroll   = this.scrollPosition()

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -355,6 +355,32 @@ describe Capybara::Session do
 
         @session.within_window 'popup' do
           @session.html.should include('slow page')
+          @session.evaluate_script('window.close()')
+        end
+      end
+
+      it 'can access a second window of the same name' do
+        @session.visit '/'
+
+        @session.evaluate_script <<-CODE
+          setTimeout(function() {
+            window.open('/poltergeist/simple', 'popup')
+          }, 0)
+        CODE
+
+        @session.within_window 'popup' do
+          @session.html.should include('Test')
+          @session.evaluate_script('window.close()')
+        end
+
+        @session.evaluate_script <<-CODE
+          setTimeout(function() {
+            window.open('/poltergeist/simple', 'popup')
+          }, 0)
+        CODE
+
+        @session.within_window 'popup' do
+          @session.html.should include('Test')
         end
       end
     end


### PR DESCRIPTION
Poltergeist was caching the page returned from getPage.  If a popup
window was opened and given a name, then closed, and a new one was
opened with the same name, we couldn't see it because we still had the
old page cached.

This change removes the cache and instead always asks phantomJS for the
page.

Fixes #312
