### PR TITLE
Improve PhantomJS version checking

### DIFF
--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -88,8 +88,14 @@ module Capybara::Poltergeist
 
       if version.nil? || $? != 0
         raise PhantomJSFailed.new($?)
-      elsif version.chomp < PHANTOMJS_VERSION
-        raise PhantomJSTooOld.new(version)
+      else
+        major, minor, build = version.chomp.split('.').map(&:to_i)
+        min_major, min_minor, min_build = PHANTOMJS_VERSION.split('.').map(&:to_i)
+        if major < min_major ||
+            major == min_major && minor < min_minor ||
+            major == min_major && minor == min_minor && build < min_build
+          raise PhantomJSTooOld.new(version)
+        end
       end
 
       @phantomjs_version_checked = true

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -12,6 +12,12 @@ module Capybara::Poltergeist
       expect { subject.start }.to raise_error(PhantomJSTooOld)
     end
 
+    it "doesn't raise an error if phantomjs is too new" do
+      `true` # stubbing $?
+      subject.stub(:`).with('phantomjs --version').and_return("1.10.0 (development)\n")
+      expect { subject.start }.to_not raise_error(PhantomJSTooOld)
+    end
+
     it 'shows the detected version in the version error message' do
       `true` # stubbing $?
       subject.stub(:`).with('phantomjs --version').and_return("1.3.0\n")


### PR DESCRIPTION
Naive implementation of raw string comparison fails on version starting from '1.10.0'. The new implementation converts version parts to integers and checks them in turn starting from major part.
