### PR TITLE
Disallow breaking version 0.5.0 of faye-websocket

### DIFF
--- a/poltergeist.gemspec
+++ b/poltergeist.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "capybara",       "~> 2.1.0"
   s.add_dependency "http_parser.rb", "~> 0.5.3"
-  s.add_dependency "faye-websocket", "~> 0.4", ">= 0.4.4"
+  s.add_dependency "faye-websocket", ">= 0.4.4", "< 0.5.0"
 
   s.add_development_dependency 'rspec',              '~> 2.12'
   s.add_development_dependency 'sinatra',            '~> 1.0'


### PR DESCRIPTION
Their 0.5.0 release broke some APIs that Poltergeist uses. See #320.
