### PR TITLE
Fix bug with has_css

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Include as much information as possible. For example:
     (Ryan Schlesinger) [Issue #312]
 *   Fix "wrong exec option symbol: pgroup" error on windows (Andrew Meyer)
     [Issue #314]
+*   Fix NoMethodError when using has_css with a count on svg elements
 
 ### 1.3.0 ###
 

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -131,7 +131,7 @@ module Capybara::Poltergeist
     private
 
     def filter_text(text)
-      text.gsub(NBSP, ' ').gsub(/\s+/u, ' ').strip
+      text.to_s.gsub(NBSP, ' ').gsub(/\s+/u, ' ').strip
     end
   end
 end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -36,6 +36,12 @@ describe Capybara::Session do
         @session.current_path.should == '/'
       end
 
+      it "doesn't raise error when asserting svg elements with a count that is not what is in the dom" do
+        @session.visit('/poltergeist/with_js')
+        expect { @session.has_css?('svg circle', count: 2) }.to_not raise_error
+        @session.should_not have_css('svg circle', count: 2)
+      end
+
       context "when someone (*cough* prototype *cough*) messes with Array#toJSON" do
         before do
           @session.visit("/poltergeist/index")

--- a/spec/support/views/with_js.erb
+++ b/spec/support/views/with_js.erb
@@ -48,5 +48,8 @@
     <p id="value_on_keyup"></p>
     <div id="off-the-left"><a href="/" id="foo">O hai</a></div>
     <a href="/" id="hidden_link"><span>Hidden link</span></a>
+    <svg id='svg-with-circle'>
+      <circle cx="60" cy="60" r="50"/>
+    </svg>
   </body>
 </html>


### PR DESCRIPTION
When using has_css with a count, I was finding that an error is
raised casued by trying to gsub on nil when the element is not
present. This fix avoids that by casting to a string first,
ensuring the gsub method is available.

I think this was caused by this line mapping the result to text:

```
From: /Users/alex/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/capybara-2.1.0/lib/capybara/result.rb @ line 41 Capybara::Result#failure_message:

    38: def failure_message
    39:   message = Capybara::Helpers.failure_message(@query.description, @query.options)
    40:   if count > 0
 => 41:     message << ", found #{count} #{Capybara::Helpers.declension("match", "matches", count)}: " << @result.map(&:text).map(&:inspect).join(", ")
    42:   else
    43:     message << " but there were no matches"
    44:   end
    45:   unless @rest.empty?
    46:     elements = @rest.map(&:text).map(&:inspect).join(", ")
    47:     message << ". Also found " << elements << ", which matched the selector but not all filters."
    48:   end
    49:   message
    50: end
```
