### PR TITLE
Fix #337 ability to set header only on initial request

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,21 @@ page.driver.headers # => { "User-Agent" => "Poltergeist", "Referer" => "https://
 ```
 
 Notice that `headers=` will overwrite already set headers. You should use
-`add_headers` if you want to add a few more. The extra headers will apply to all
+`add_headers` if you want to add a few more. These headers will apply to all
 subsequent HTTP requests (including requests for assets, AJAX, etc). They will
-be automatically cleared at the end of the test.
+be automatically cleared at the end of the test. You have ability to set headers
+only for the initial request:
+
+``` ruby
+page.driver.headers = { "User-Agent" => "Poltergeist" }
+page.driver.add_header("Referer", "http://example.com", permanent: false)
+page.driver.headers # => { "User-Agent" => "Poltergeist", "Referer" => "http://example.com" }
+visit(login_path)
+page.driver.headers # => { "User-Agent" => "Poltergeist" }
+```
+
+This way your temporary headers will be sent only for the initial request, all
+subsequent request will only contain your permanent headers.
 
 ### Inspecting network traffic ###
 
@@ -361,6 +373,7 @@ Include as much information as possible. For example:
 *   Can set cookies for given domain
 *   Can get open window names with window_handles [Issue #178]
 *   Added ability to read and append headers (Dmitry Vorotilin) [Issue #187]
+*   Added ability to set headers only for the first request (Dmitry Vorotilin) [Issue #337]
 
 #### Bug fixes ####
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -190,6 +190,10 @@ module Capybara::Poltergeist
       command 'add_headers', headers
     end
 
+    def add_header(header, permanent)
+      command 'add_header', header, permanent
+    end
+
     def response_headers
       command 'response_headers'
     end

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -284,6 +284,10 @@ class Poltergeist.Browser
       allHeaders[name] = value
     this.set_headers(allHeaders)
 
+  add_header: (header, permanent) ->
+    @page.addTempHeader(header) unless permanent
+    this.add_headers(header)
+
   response_headers: ->
     this.sendResponse(@page.responseHeaders())
 

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -394,6 +394,13 @@ Poltergeist.Browser = (function() {
     return this.set_headers(allHeaders);
   };
 
+  Browser.prototype.add_header = function(header, permanent) {
+    if (!permanent) {
+      this.page.addTempHeader(header);
+    }
+    return this.add_headers(header);
+  };
+
   Browser.prototype.response_headers = function() {
     return this.sendResponse(this.page.responseHeaders());
   };

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -20,6 +20,7 @@ Poltergeist.WebPage = (function() {
     this._source = null;
     this._errors = [];
     this._networkTraffic = {};
+    this._temp_headers = {};
     this.frames = [];
     _ref = WebPage.CALLBACKS;
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
@@ -56,6 +57,7 @@ Poltergeist.WebPage = (function() {
   WebPage.prototype.onInitializedNative = function() {
     this._source = null;
     this.injectAgent();
+    this.removeTempHeaders();
     return this.setScrollPosition({
       left: 0,
       top: 0
@@ -228,6 +230,29 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.setCustomHeaders = function(headers) {
     return this["native"].customHeaders = headers;
+  };
+
+  WebPage.prototype.addTempHeader = function(header) {
+    var name, value, _results;
+
+    _results = [];
+    for (name in header) {
+      value = header[name];
+      _results.push(this._temp_headers[name] = value);
+    }
+    return _results;
+  };
+
+  WebPage.prototype.removeTempHeaders = function() {
+    var allHeaders, name, value, _ref2;
+
+    allHeaders = this.getCustomHeaders();
+    _ref2 = this._temp_headers;
+    for (name in _ref2) {
+      value = _ref2[name];
+      delete allHeaders[name];
+    }
+    return this.setCustomHeaders(allHeaders);
   };
 
   WebPage.prototype.pushFrame = function(name) {

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -15,6 +15,7 @@ class Poltergeist.WebPage
     @_source         = null
     @_errors         = []
     @_networkTraffic = {}
+    @_temp_headers   = {}
     @frames          = []
 
     for callback in WebPage.CALLBACKS
@@ -33,6 +34,7 @@ class Poltergeist.WebPage
   onInitializedNative: ->
     @_source = null
     @injectAgent()
+    this.removeTempHeaders()
     this.setScrollPosition(left: 0, top: 0)
 
   injectAgent: ->
@@ -150,6 +152,16 @@ class Poltergeist.WebPage
 
   setCustomHeaders: (headers) ->
     @native.customHeaders = headers
+
+  addTempHeader: (header) ->
+    for name, value of header
+      @_temp_headers[name] = value
+
+  removeTempHeaders: ->
+    allHeaders = this.getCustomHeaders()
+    for name, value of @_temp_headers
+      delete allHeaders[name]
+    this.setCustomHeaders(allHeaders)
 
   pushFrame: (name) ->
     if @native.switchToFrame(name)

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -178,6 +178,11 @@ module Capybara::Poltergeist
       browser.add_headers(headers)
     end
 
+    def add_header(name, value, options = {})
+      permanent = options.fetch(:permanent, true)
+      browser.add_header({ name => value }, permanent)
+    end
+
     def response_headers
       browser.response_headers
     end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -163,6 +163,27 @@ module Capybara::Poltergeist
         expect(@driver.body).to include('HOST: foo.com')
         expect(@driver.body).to include('APPENDED: true')
       end
+
+      it 'sets headers on the initial request' do
+        @driver.headers = { 'PermanentA' => 'a' }
+        @driver.add_headers('PermanentB' => 'b')
+        @driver.add_header('Referer', 'http://google.com', :permanent => false)
+        @driver.add_header('TempA', 'a', :permanent => false)
+
+        @session.visit('/poltergeist/headers_with_ajax')
+        initial_request = @session.find(:css, '#initial_request').text
+        ajax_request = @session.find(:css, '#ajax_request').text
+
+        expect(initial_request).to include('PERMANENTA: a')
+        expect(initial_request).to include('PERMANENTB: b')
+        expect(initial_request).to include('REFERER: http://google.com')
+        expect(initial_request).to include('TEMPA: a')
+
+        expect(ajax_request).to include('PERMANENTA: a')
+        expect(ajax_request).to include('PERMANENTB: b')
+        expect(ajax_request).not_to include('REFERER: http://google.com')
+        expect(ajax_request).not_to include('TEMPA: a')
+      end
     end
 
     it 'supports rendering the page with a nonstring path' do

--- a/spec/support/views/headers_with_ajax.erb
+++ b/spec/support/views/headers_with_ajax.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="text/javascript">
+    window.onload = function() {
+      var request = new XMLHttpRequest();
+      request.open('GET', '/poltergeist/headers', false);
+      request.send();
+
+      if (request.status === 200) {
+        var div = document.getElementById('ajax_request');
+        div.innerHTML = request.responseText;
+      }
+    }
+  </script>
+</head>
+<body>
+  <div id="initial_request">
+    <% for header in request.env.select {|k,v| k.match("^HTTP.*")} %>
+      <%=header[0].split('_',2)[1]%>: <%=header[1]%>
+    <% end %>
+  </div>
+  <div id="ajax_request"></div>
+</body>
+</html>


### PR DESCRIPTION
It's good described in #337 and I'm totally agree with that. I faced another trouble when was preparing PR, it was double firing of `onInitialized` event.

PhantomJS has `customHeaders` property but headers will be sent to the server for every request. If we set Referer header it will appear in every subsequent ajax request. PhantomJS doesn't have any specific option to set headers just for the first request, instead they suggest a workaround, you can reset headers inside `onInitialized` callback. This commit adds second option to `driver.add_headers` method, setting this as false you can set given headers only for the first request.

/cc @jonleighton @yaauie
