### PR TITLE
Fix typo

### DIFF
--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -54,7 +54,7 @@ module Capybara::Poltergeist
     def self.process_killer(pid)
       proc do
         begin
-          Proces.kill('KILL', pid)
+          Process.kill('KILL', pid)
         rescue Errno::ESRCH, Errno::ECHILD
         end
       end


### PR DESCRIPTION
Just fixed a typo.

What a badly behaved child process. [Perhaps here there's a hint at a simpler kill](http://www.evans.io/posts/killing-child-processes-on-parent-exit-prctl/).
