### PR TITLE
Add ability to scroll, and ability to capture a specific element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Added ability to read and append headers (Dmitry Vorotilin) [Issue #187]
 *   Added ability to set headers only for the first request (Dmitry Vorotilin) [Issue #337]
 *   Depend on Cliver for command-line dependency detection.
+*   Added ability to scroll with `driver.scroll_to left, top` (Jim Lim)
+*   Added ability to capture an element  with `driver.render selector: '#id'` (Jim Lim)
 
 #### Bug fixes ####
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -157,8 +157,16 @@ module Capybara::Poltergeist
       command 'reset'
     end
 
+    def scroll_to(left, top)
+      command 'scroll_to', left, top
+    end
+
     def render(path, options = {})
-      command 'render', path.to_s, !!options[:full]
+      if !!options[:full] && options.has_key?(:selector)
+        warn "Ignoring :selector in #render since :full => true was given at #{caller.first}"
+        options.delete(:selector)
+      end
+      command 'render', path.to_s, !!options[:full], options[:selector]
     end
 
     def resize(width, height)

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -246,7 +246,11 @@ class Poltergeist.Browser
     this.resetPage()
     this.sendResponse(true)
 
-  render: (path, full) ->
+  scroll_to: (left, top) ->
+    @page.setScrollPosition(left: left, top: top)
+    this.sendResponse(true)
+
+  render: (path, full, selector=null) ->
     dimensions = @page.validatedDimensions()
     document   = dimensions.document
     viewport   = dimensions.viewport
@@ -256,6 +260,11 @@ class Poltergeist.Browser
       @page.setClipRect(left: 0, top: 0, width: document.width, height: document.height)
       @page.render(path)
       @page.setScrollPosition(left: dimensions.left, top: dimensions.top)
+    else if selector
+      previous_clip = @page.clipRect
+      @page.setClipRect(@page.elementBounds(selector))
+      @page.render(path)
+      @page.setClipRect(previous_clip)
     else
       @page.setClipRect(left: 0, top: 0, width: viewport.width, height: viewport.height)
       @page.render(path)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -325,9 +325,19 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(true);
   };
 
-  Browser.prototype.render = function(path, full) {
-    var dimensions, document, viewport;
+  Browser.prototype.scroll_to = function(left, top) {
+    this.page.setScrollPosition({
+      left: left,
+      top: top
+    });
+    return this.sendResponse(true);
+  };
 
+  Browser.prototype.render = function(path, full, selector) {
+    var dimensions, document, previous_clip, viewport;
+    if (selector == null) {
+      selector = null;
+    }
     dimensions = this.page.validatedDimensions();
     document = dimensions.document;
     viewport = dimensions.viewport;
@@ -347,6 +357,11 @@ Poltergeist.Browser = (function() {
         left: dimensions.left,
         top: dimensions.top
       });
+    } else if (selector) {
+      previous_clip = this.page.clipRect;
+      this.page.setClipRect(this.page.elementBounds(selector));
+      this.page.render(path);
+      this.page.setClipRect(previous_clip);
     } else {
       this.page.setClipRect({
         left: 0,

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -220,6 +220,12 @@ Poltergeist.WebPage = (function() {
     return this["native"].clipRect = rect;
   };
 
+  WebPage.prototype.elementBounds = function(selector) {
+    return this["native"].evaluate(function(selector) {
+      return document.querySelector(selector).getBoundingClientRect();
+    }, selector);
+  };
+
   WebPage.prototype.setUserAgent = function(userAgent) {
     return this["native"].settings.userAgent = userAgent;
   };

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -144,6 +144,12 @@ class Poltergeist.WebPage
   setClipRect: (rect) ->
     @native.clipRect = rect
 
+  elementBounds: (selector) ->
+    @native.evaluate(
+      (selector) -> document.querySelector(selector).getBoundingClientRect(),
+      selector
+    )
+
   setUserAgent: (userAgent) ->
     @native.settings.userAgent = userAgent
 

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -162,6 +162,10 @@ module Capybara::Poltergeist
     end
     alias_method :resize_window, :resize
 
+    def scroll_to(left, top)
+      browser.scroll_to(left, top)
+    end
+
     def network_traffic
       browser.network_traffic
     end


### PR DESCRIPTION
For example, use

``` ruby
driver.scroll_to 200, 100
```

to set scrollX to 200 and scrollY to 100.

Use

```
driver.render selector: '#penultimate'
```

to clip the screenshot to the bounds of the selected element.
