### PR TITLE
Fix url escaping

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -30,7 +30,10 @@ module Capybara::Poltergeist
     end
 
     def current_url
-      command 'current_url'
+      url = command 'current_url'
+      url.split('#', 2).compact.map do |part|
+        URI::escape(URI::unescape(part))
+      end.join('#')
     end
 
     def status_code

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -359,13 +359,11 @@ describe Capybara::Session do
     end
 
     it 'supports retrieving the URL of pages with escaped characters' do
-      pending "see issue #349"
       @session.visit '/poltergeist/arbitrary_path/200/foo%20bar'
       URI.parse(@session.driver.current_url).path.should eq '/poltergeist/arbitrary_path/200/foo%20bar'
     end
 
     it 'supports retrieving the URL of pages with unescaped characters' do
-      pending "see issue #349"
       @session.visit '/poltergeist/arbitrary_path/200/foo bar'
       URI.parse(@session.driver.current_url).path.should eq '/poltergeist/arbitrary_path/200/foo%20bar'
     end


### PR DESCRIPTION
First, I think this is an ugly patch, but it is a temporary one that should
survive an upstream fix to PhantomJS with only a small performance penalty.

@jredburn [wrote](https://github.com/jonleighton/poltergeist/issues/349#issuecomment-21148290)

> Is it expected behavior that PhantomJS's `window.location.toString()` will
> return a non-escaped URL?

I don't believe this is the case. In every browser I test with locally, that
command in a console yields a properly-escaped URL. The fact that it does
not in PhantomJS is surprising.
