### PR TITLE
IFrame clicks don't take into account padding on the IFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 #### Bug fixes ####
 
+*   Fix clicks inside `within_frame` not taking into account padding on the
+    frame [Issue #377]
 *   Fix `within_window` finding window after close/open
     (Ryan Schlesinger) [Issue #312]
 *   Fix "wrong exec option symbol: pgroup" error on windows (Andrew Meyer)

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -214,11 +214,12 @@ class PoltergeistAgent.Node
     offset = { top: 0, left: 0 }
 
     while win.frameElement
-      rect = window.frameElement.getClientRects()[0]
-      win  = win.parent
-
-      offset.top  += rect.top
-      offset.left += rect.left
+      rect  = win.frameElement.getClientRects()[0]
+      style = win.getComputedStyle(win.frameElement)
+      win   = win.parent
+      
+      offset.top  += rect.top + parseInt(style.getPropertyValue("padding-top"), 10)
+      offset.left += rect.left + parseInt(style.getPropertyValue("padding-left"), 10)
 
     offset
 

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -8,7 +8,6 @@ PoltergeistAgent = (function() {
 
   PoltergeistAgent.prototype.externalCall = function(name, args) {
     var error;
-
     try {
       return {
         value: this[name].apply(this, args)
@@ -26,7 +25,6 @@ PoltergeistAgent = (function() {
 
   PoltergeistAgent.stringify = function(object) {
     var error;
-
     try {
       return JSON.stringify(object, function(key, value) {
         if (Array.isArray(this[key])) {
@@ -51,7 +49,6 @@ PoltergeistAgent = (function() {
 
   PoltergeistAgent.prototype.find = function(method, selector, within) {
     var el, error, i, results, xpath, _i, _len, _results;
-
     if (within == null) {
       within = document;
     }
@@ -60,7 +57,6 @@ PoltergeistAgent = (function() {
         xpath = document.evaluate(selector, within, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
         results = (function() {
           var _i, _ref, _results;
-
           _results = [];
           for (i = _i = 0, _ref = xpath.snapshotLength; 0 <= _ref ? _i < _ref : _i > _ref; i = 0 <= _ref ? ++_i : --_i) {
             _results.push(xpath.snapshotItem(i));
@@ -100,13 +96,11 @@ PoltergeistAgent = (function() {
 
   PoltergeistAgent.prototype.get = function(id) {
     var _base;
-
     return (_base = this.nodes)[id] || (_base[id] = new PoltergeistAgent.Node(this, this.elements[id]));
   };
 
   PoltergeistAgent.prototype.nodeCall = function(id, name, args) {
     var node;
-
     node = this.get(id);
     if (node.isObsolete()) {
       throw new PoltergeistAgent.ObsoleteNode;
@@ -170,7 +164,6 @@ PoltergeistAgent.Node = (function() {
   Node.prototype.isObsolete = function() {
     var obsolete,
       _this = this;
-
     obsolete = function(element) {
       if (element.parentNode != null) {
         if (element.parentNode === document) {
@@ -187,7 +180,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.changed = function() {
     var event;
-
     event = document.createEvent('HTMLEvents');
     event.initEvent('change', true, false);
     return this.element.dispatchEvent(event);
@@ -195,7 +187,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.input = function() {
     var event;
-
     event = document.createEvent('HTMLEvents');
     event.initEvent('input', true, false);
     return this.element.dispatchEvent(event);
@@ -203,7 +194,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.keyupdowned = function(eventName, keyCode) {
     var event;
-
     event = document.createEvent('UIEvents');
     event.initEvent(eventName, true, true);
     event.keyCode = keyCode;
@@ -214,7 +204,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.keypressed = function(altKey, ctrlKey, shiftKey, metaKey, keyCode, charCode) {
     var event;
-
     event = document.createEvent('UIEvents');
     event.initEvent('keypress', true, true);
     event.window = this.agent.window;
@@ -258,7 +247,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.value = function() {
     var option, _i, _len, _ref, _results;
-
     if (this.element.tagName === 'SELECT' && this.element.multiple) {
       _ref = this.element.children;
       _results = [];
@@ -276,7 +264,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.set = function(value) {
     var char, keyCode, _i, _len;
-
     if (this.element.readOnly) {
       return;
     }
@@ -342,25 +329,24 @@ PoltergeistAgent.Node = (function() {
   };
 
   Node.prototype.frameOffset = function() {
-    var offset, rect, win;
-
+    var offset, rect, style, win;
     win = window;
     offset = {
       top: 0,
       left: 0
     };
     while (win.frameElement) {
-      rect = window.frameElement.getClientRects()[0];
+      rect = win.frameElement.getClientRects()[0];
+      style = win.getComputedStyle(win.frameElement);
       win = win.parent;
-      offset.top += rect.top;
-      offset.left += rect.left;
+      offset.top += rect.top + parseInt(style.getPropertyValue("padding-top"), 10);
+      offset.left += rect.left + parseInt(style.getPropertyValue("padding-left"), 10);
     }
     return offset;
   };
 
   Node.prototype.position = function() {
     var frameOffset, pos, rect;
-
     rect = this.element.getClientRects()[0];
     if (!rect) {
       throw new PoltergeistAgent.ObsoleteNode;
@@ -379,7 +365,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.trigger = function(name) {
     var event;
-
     if (Node.EVENTS.MOUSE.indexOf(name) !== -1) {
       event = document.createEvent('MouseEvent');
       event.initMouseEvent(name, true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
@@ -394,7 +379,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.mouseEventTest = function(x, y) {
     var el, frameOffset, origEl;
-
     frameOffset = this.frameOffset();
     x -= frameOffset.left;
     y -= frameOffset.top;
@@ -416,7 +400,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.getSelector = function(el) {
     var className, selector, _i, _len, _ref;
-
     selector = el.tagName !== 'HTML' ? this.getSelector(el.parentNode) + ' ' : '';
     selector += el.tagName.toLowerCase();
     if (el.id) {
@@ -432,7 +415,6 @@ PoltergeistAgent.Node = (function() {
 
   Node.prototype.characterToKeyCode = function(character) {
     var code, specialKeys;
-
     code = character.toUpperCase().charCodeAt(0);
     specialKeys = {
       96: 192,

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -13,7 +13,6 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.resetPage = function() {
     var _this = this;
-
     if (this.page != null) {
       this.page.release();
       phantom.clearCookies();
@@ -50,7 +49,6 @@ Poltergeist.Browser = (function() {
     };
     return this.page.onPageCreated = function(sub_page) {
       var name;
-
       if (_this.state === 'awaiting_sub_page') {
         name = _this.page_name;
         _this.page_name = null;
@@ -83,7 +81,6 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.sendResponse = function(response) {
     var errors;
-
     errors = this.page.errors();
     this.page.clearErrors();
     if (errors.length > 0 && this.js_errors) {
@@ -108,7 +105,6 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.visit = function(url) {
     var prev_url;
-
     this.setState('loading');
     prev_url = this.page.source() === null ? 'about:blank' : this.page.currentUrl();
     this.page.open(url);
@@ -172,7 +168,6 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.select_file = function(page_id, id, value) {
     var node;
-
     node = this.node(page_id, id);
     this.page.beforeUpload(node.id);
     this.page.uploadFile('[_poltergeist_selected]', value);
@@ -207,7 +202,6 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.push_frame = function(name, timeout) {
     var _this = this;
-
     if (timeout == null) {
       timeout = new Date().getTime() + 2000;
     }
@@ -239,7 +233,6 @@ Poltergeist.Browser = (function() {
   Browser.prototype.push_window = function(name) {
     var sub_page,
       _this = this;
-
     sub_page = this.page.getPage(name);
     if (sub_page) {
       if (sub_page.currentUrl() === 'about:blank') {
@@ -261,7 +254,6 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.pop_window = function() {
     var prev_page;
-
     prev_page = this.page_stack.pop();
     if (prev_page) {
       this.page = prev_page;
@@ -272,7 +264,6 @@ Poltergeist.Browser = (function() {
   Browser.prototype.mouse_event = function(page_id, id, name) {
     var node,
       _this = this;
-
     node = this.node(page_id, id);
     this.setState('mouse_event');
     this.last_mouse_event = node.mouseEvent(name);
@@ -400,7 +391,6 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.add_headers = function(headers) {
     var allHeaders, name, value;
-
     allHeaders = this.page.getCustomHeaders();
     for (name in headers) {
       value = headers[name];

--- a/lib/capybara/poltergeist/client/compiled/main.js
+++ b/lib/capybara/poltergeist/client/compiled/main.js
@@ -5,7 +5,6 @@ var Poltergeist, _ref,
 Poltergeist = (function() {
   function Poltergeist(port, width, height) {
     var that;
-
     this.browser = new Poltergeist.Browser(this, width, height);
     this.connection = new Poltergeist.Connection(this, port);
     that = this;
@@ -17,7 +16,6 @@ Poltergeist = (function() {
 
   Poltergeist.prototype.runCommand = function(command) {
     var error;
-
     this.running = true;
     try {
       return this.browser.runCommand(command.name, command.args);

--- a/lib/capybara/poltergeist/client/compiled/node.js
+++ b/lib/capybara/poltergeist/client/compiled/node.js
@@ -19,7 +19,6 @@ Poltergeist.Node = (function() {
   _fn = function(name) {
     return Node.prototype[name] = function() {
       var args;
-
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
       return this.page.nodeCall(this.id, name, args);
     };
@@ -31,7 +30,6 @@ Poltergeist.Node = (function() {
 
   Node.prototype.mouseEventPosition = function() {
     var middle, pos, viewport;
-
     viewport = this.page.viewportSize();
     pos = this.position();
     middle = function(start, end, size) {
@@ -45,7 +43,6 @@ Poltergeist.Node = (function() {
 
   Node.prototype.mouseEvent = function(name) {
     var pos, test;
-
     this.scrollIntoView();
     pos = this.mouseEventPosition();
     test = this.mouseEventTest(pos.x, pos.y);
@@ -59,7 +56,6 @@ Poltergeist.Node = (function() {
 
   Node.prototype.dragTo = function(other) {
     var otherPosition, position;
-
     this.scrollIntoView();
     position = this.mouseEventPosition();
     otherPosition = other.mouseEventPosition();

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -14,7 +14,6 @@ Poltergeist.WebPage = (function() {
 
   function WebPage(_native) {
     var callback, _i, _len, _ref;
-
     this["native"] = _native;
     this["native"] || (this["native"] = require('webpage').create());
     this._source = null;
@@ -33,7 +32,6 @@ Poltergeist.WebPage = (function() {
   _fn = function(command) {
     return WebPage.prototype[command] = function() {
       var args;
-
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
       return this.runCommand(command, args);
     };
@@ -66,7 +64,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.injectAgent = function() {
     var extension, _k, _len2, _ref2, _results;
-
     if (this["native"].evaluate(function() {
       return typeof __poltergeist;
     }) === "undefined") {
@@ -107,7 +104,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.onErrorNative = function(message, stack) {
     var stackString;
-
     stackString = message;
     stack.forEach(function(frame) {
       stackString += "\n";
@@ -136,7 +132,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.onResourceReceivedNative = function(response) {
     var _ref2;
-
     if ((_ref2 = this._networkTraffic[response.id]) != null) {
       _ref2.responseParts.push(response);
     }
@@ -180,7 +175,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.responseHeaders = function() {
     var headers;
-
     headers = {};
     this._responseHeaders.forEach(function(item) {
       return headers[item.name] = item.value;
@@ -240,7 +234,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.addTempHeader = function(header) {
     var name, value, _results;
-
     _results = [];
     for (name in header) {
       value = header[name];
@@ -251,7 +244,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.removeTempHeaders = function() {
     var allHeaders, name, value, _ref2;
-
     allHeaders = this.getCustomHeaders();
     _ref2 = this._temp_headers;
     for (name in _ref2) {
@@ -281,7 +273,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.getPage = function(name) {
     var page;
-
     page = this["native"].getPage(name);
     if (page) {
       return new Poltergeist.WebPage(page);
@@ -290,7 +281,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.dimensions = function() {
     var scroll, viewport;
-
     scroll = this.scrollPosition();
     viewport = this.viewportSize();
     return {
@@ -305,7 +295,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.validatedDimensions = function() {
     var dimensions, document;
-
     dimensions = this.dimensions();
     document = dimensions.document;
     if (dimensions.right > document.width) {
@@ -334,7 +323,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.evaluate = function() {
     var args, fn;
-
     fn = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
     this.injectAgent();
     return JSON.parse(this["native"].evaluate("function() { return PoltergeistAgent.stringify(" + (this.stringifyCall(fn, args)) + ") }"));
@@ -342,7 +330,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.execute = function() {
     var args, fn;
-
     fn = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
     return this["native"].evaluate("function() { " + (this.stringifyCall(fn, args)) + " }");
   };
@@ -357,11 +344,9 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.bindCallback = function(name) {
     var that;
-
     that = this;
     return this["native"][name] = function() {
       var result;
-
       if (that[name + 'Native'] != null) {
         result = that[name + 'Native'].apply(that, arguments);
       }
@@ -373,7 +358,6 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.runCommand = function(name, args) {
     var result;
-
     result = this.evaluate(function(name, args) {
       return __poltergeist.externalCall(name, args);
     }, name, args);

--- a/spec/support/views/nested_frame_test.erb
+++ b/spec/support/views/nested_frame_test.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style type="text/css">
+    body {
+      background: yellow;
+    }
+  </style>
+</head>
+<body>
+  <iframe src="/poltergeist/click_test" name="inner_frame"></iframe>
+</body>
+</html>


### PR DESCRIPTION
Fixes #377 by calculating top and left padding on the iframe and adding that to the calculated frameOffset.

Calculates the padding using window.getComputedStyle so frames w/ no padding and frames w/ padding defined as em, %, etc... will also work.

Uses parseInt as the padding properties are ultimately returned as a string w/ "px" appended.

Caveat: I'm not an expert on the DOM API, so there may be a cleaner way to either get those padding values or get the calculated offset + padding in the first place.
