### PR TITLE
Adding the ability to pass a paper_size option to save_screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 *   Depend on Cliver for command-line dependency detection.
 *   Added ability to scroll with `driver.scroll_to left, top` (Jim Lim)
 *   Added ability to capture an element  with `driver.render selector: '#id'` (Jim Lim)
+*   Added ability to set paper_size via a driver setter (Philippe Lehoux)
 
 #### Bug fixes ####
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -169,6 +169,10 @@ module Capybara::Poltergeist
       command 'render', path.to_s, !!options[:full], options[:selector]
     end
 
+    def set_paper_size(size)
+      command 'set_paper_size', size
+    end
+
     def resize(width, height)
       command 'resize', width, height
     end

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -271,6 +271,10 @@ class Poltergeist.Browser
 
     this.sendResponse(true)
 
+  set_paper_size: (size) ->
+    @page.setPaperSize(size)
+    this.sendResponse(true)
+
   resize: (width, height) ->
     @page.setViewportSize(width: width, height: height)
     this.sendResponse(true)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -365,6 +365,11 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(true);
   };
 
+  Browser.prototype.set_paper_size = function(size) {
+    this.page.setPaperSize(size);
+    return this.sendResponse(true);
+  };
+
   Browser.prototype.resize = function(width, height) {
     this.page.setViewportSize({
       width: width,

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -198,6 +198,10 @@ Poltergeist.WebPage = (function() {
     return this["native"].viewportSize = size;
   };
 
+  WebPage.prototype.setPaperSize = function(size) {
+    return this["native"].paperSize = size;
+  };
+
   WebPage.prototype.scrollPosition = function() {
     return this["native"].scrollPosition;
   };

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -132,6 +132,9 @@ class Poltergeist.WebPage
   setViewportSize: (size) ->
     @native.viewportSize = size
 
+  setPaperSize: (size) ->
+    @native.paperSize = size
+
   scrollPosition: ->
     @native.scrollPosition
 

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -157,6 +157,10 @@ module Capybara::Poltergeist
     end
     alias_method :render, :save_screenshot
 
+    def paper_size=(size = {})
+      browser.set_paper_size(size)
+    end
+
     def resize(width, height)
       browser.resize(width, height)
     end

--- a/poltergeist.gemspec
+++ b/poltergeist.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sinatra',            '~> 1.0'
   s.add_development_dependency 'rake',               '~> 10.0'
   s.add_development_dependency 'image_size',         '~> 1.0'
+  s.add_development_dependency 'pdf-reader',         '~> 1.3.3'
   s.add_development_dependency 'coffee-script',      '~> 2.2.0'
   s.add_development_dependency 'guard-coffeescript', '~> 1.0.0'
   s.add_development_dependency 'rspec-rerun',        '~> 0.1'

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'image_size'
+require 'pdf/reader'
 
 module Capybara::Poltergeist
   describe Driver do
@@ -143,6 +144,19 @@ module Capybara::Poltergeist
           }();
         EOS
         ImageSize.new(f.read).size.should == size
+      end
+    end
+
+    it 'changes Pdf size rendered by #save_screenshot when #paper_size= is set' do
+      file = POLTERGEIST_ROOT + '/spec/tmp/document.pdf'
+      @session.visit('/poltergeist/long_page')
+      @driver.paper_size = { width: '1in', height: '1in'}
+      @driver.save_screenshot(file)
+      reader = PDF::Reader.new(file)
+      reader.pages.each do |page|
+        bbox   = page.attributes[:MediaBox]
+        width  = (bbox[2] - bbox[0]) / 72
+        width.should == 1
       end
     end
 


### PR DESCRIPTION
Enabling something like: 

``` ruby
save_screenshot('helloworld.pdf', paper_size: { format: 'Letter',  border: '0.75in' })
```
