### PR TITLE
Fix #202 implemented send_keys [ci skip]

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -179,6 +179,10 @@ module Capybara::Poltergeist
       command 'resize', width, height
     end
 
+    def send_keys(page_id, id, type, keys, modifier)
+      command 'send_keys', page_id, id, type, keys, modifier
+    end
+
     def network_traffic
       command('network_traffic').values.map do |event|
         NetworkTraffic::Request.new(

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -250,6 +250,10 @@ class Poltergeist.Browser
     @page.setScrollPosition(left: left, top: top)
     this.sendResponse(true)
 
+  send_keys: (page_id, id, type, keys, modifier) ->
+    # this.execute("document.querySelector('#change_me').focus()")
+    this.sendResponse this.node(page_id, id).sendEvent(type, keys, modifier)
+
   render_base64: (format, full, selector = null)->
     this.set_clip_rect(full, selector)
     encoded_image = @page.renderBase64(format)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -324,6 +324,10 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(true);
   };
 
+  Browser.prototype.send_keys = function(page_id, id, type, keys, modifier) {
+    return this.sendResponse(this.node(page_id, id).sendEvent(type, keys, modifier));
+  };
+
   Browser.prototype.render_base64 = function(format, full, selector) {
     var encoded_image;
     if (selector == null) {

--- a/lib/capybara/poltergeist/client/compiled/node.js
+++ b/lib/capybara/poltergeist/client/compiled/node.js
@@ -54,6 +54,12 @@ Poltergeist.Node = (function() {
     }
   };
 
+  Node.prototype.sendEvent = function(type, keys, modifier) {
+    this.trigger('focus');
+    this.page.sendEvent(type, keys, null, null, modifier);
+    return true;
+  };
+
   Node.prototype.dragTo = function(other) {
     var otherPosition, position;
     this.scrollIntoView();

--- a/lib/capybara/poltergeist/client/node.coffee
+++ b/lib/capybara/poltergeist/client/node.coffee
@@ -40,6 +40,11 @@ class Poltergeist.Node
     else
       throw new Poltergeist.MouseEventFailed(name, test.selector, pos)
 
+  sendEvent: (type, keys, modifier) ->
+    this.trigger('focus')
+    @page.sendEvent(type, keys, null, null, modifier)
+    true
+
   dragTo: (other) ->
     this.scrollIntoView()
 

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -128,6 +128,11 @@ module Capybara::Poltergeist
       command :equals, other.id
     end
 
+    def send_keys(keys, type = :keypress, modifier = nil)
+      raise Error unless [:keyup, :keypress, :keydown].include?(type)
+      command :send_keys, type, keys, modifier
+    end
+
     private
 
     def filter_text(text)

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -607,5 +607,13 @@ module Capybara::Poltergeist
       expect(@driver.browser.window_handles).to eq(["popup"])
       expect(@driver.window_handles).to eq(["popup"])
     end
+
+    context 'send_keys' do
+      it 'sends keys to webpage' do
+        @session.visit('/poltergeist/with_js')
+        @driver.find_css('#change_me').first.send_keys('hello')
+        expect(@session.find(:css, '#change_me').value).to eq('hello')
+      end
+    end
   end
 end


### PR DESCRIPTION
I have a few troubles here.
1) When I try to call `trigger('focus')` event is actually triggered but input doesn't get real focus and keypressed buttons go somewhere else. But if I run that line https://github.com/jonleighton/poltergeist/commit/deda41fd7235ba8b82346d30daf1afb750318f66#L1R254 everything starts working. Ideas?
2) I see some code https://github.com/jonleighton/poltergeist/blob/202_send_keys/lib/capybara/poltergeist/client/agent.coffee#L117
https://github.com/jonleighton/poltergeist/blob/202_send_keys/lib/capybara/poltergeist/client/agent.coffee#L242
related to key/mouse events is that because at that moment there wasn't `sendEvent` function?
