### PR TITLE
Remove .travis.yml instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,7 @@ was 1.0.2, so you should use that if you still need Ruby 1.8 support.
 There are no special steps to take. You don't need Xvfb or any running X
 server at all.
 
-[Travis CI](https://travis-ci.org/) has PhantomJS pre-installed, but it
-might not be the latest version. If you need to install the latest
-version, [check out the .travis.yml that Poltergeist
-uses](https://github.com/jonleighton/poltergeist/blob/master/.travis.yml).
+[Travis CI](https://travis-ci.org/) has PhantomJS pre-installed.
 
 Depending on your tests, one thing that you may need is some fonts. If
 you're getting errors on a CI that don't occur during development then


### PR DESCRIPTION
I'm assuming the link was meant to point people to the `before_script` which was removed in https://github.com/jonleighton/poltergeist/commit/b931466f4f269ab9d3e93ed94292ae5462228f67 .

If the instructions are still needed, the `before_script` source could be added to the README as a code block, or it could link to an older `.travis.yml` version.
