### PR TITLE
Add clear_network_traffic function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Next release ###
 
 #### Features ####
+*   Added ability to clear network traffic (Vick Vu)
 *   Added ability to set paper_size via a driver setter (Philippe Lehoux)
 *   Can support Basic HTTP authentication
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ You can inspect the network traffic (i.e. what resources have been
 loaded) on the current page by calling `page.driver.network_traffic`.
 This returns an array of request objects. A request object has a
 `response_parts` method containing data about the response chunks.
+Please note that network traffic is not cleared when you visit new page.
+You can manually clear the network traffic by calling `page.driver.clear_network_traffic`
+or `page.driver.reset`
 
 ### Manipulating cookies ###
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -188,6 +188,10 @@ module Capybara::Poltergeist
       end
     end
 
+    def clear_network_traffic
+      command('clear_network_traffic')
+    end
+
     def equals(page_id, id, other_id)
       command('equals', page_id, id, other_id)
     end

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -288,6 +288,10 @@ class Poltergeist.Browser
   network_traffic: ->
     this.sendResponse(@page.networkTraffic())
 
+  clear_network_traffic: ->
+    @page.clearNetworkTraffic()
+    this.sendResponse(true)
+
   get_headers: ->
     this.sendResponse(@page.getCustomHeaders())
 

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -388,6 +388,11 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(this.page.networkTraffic());
   };
 
+  Browser.prototype.clear_network_traffic = function() {
+    this.page.clearNetworkTraffic();
+    return this.sendResponse(true);
+  };
+
   Browser.prototype.get_headers = function() {
     return this.sendResponse(this.page.getCustomHeaders());
   };

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -154,6 +154,10 @@ Poltergeist.WebPage = (function() {
     return this._networkTraffic;
   };
 
+  WebPage.prototype.clearNetworkTraffic = function() {
+    return this._networkTraffic = {};
+  };
+
   WebPage.prototype.content = function() {
     return this["native"].frameContent;
   };

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -100,6 +100,9 @@ class Poltergeist.WebPage
   networkTraffic: ->
     @_networkTraffic
 
+  clearNetworkTraffic: ->
+    @_networkTraffic = {}
+
   content: ->
     @native.frameContent
 

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -178,6 +178,10 @@ module Capybara::Poltergeist
       browser.network_traffic
     end
 
+    def clear_network_traffic
+      browser.clear_network_traffic
+    end
+
     def headers
       browser.get_headers
     end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -490,6 +490,15 @@ module Capybara::Poltergeist
         @session.visit('/poltergeist/with_js')
         expect(@driver.network_traffic.length).to eq(4)
       end
+
+      it "gets cleared when being cleared" do
+        @session.visit('/poltergeist/with_js')
+        expect(@driver.network_traffic.length).to eq(4)
+
+        @driver.clear_network_traffic
+
+        expect(@driver.network_traffic.length).to eq(0)
+      end
     end
 
     context 'status code support' do


### PR DESCRIPTION
This function would be useful when user need to clear network traffic object. The reset function can also network traffic, however it also clears cookies.
