### PR TITLE
Added a begin around closing of IOs

### DIFF
--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -78,9 +78,17 @@ module Capybara::Poltergeist
         rescue Errno::ESRCH, Errno::ECHILD
           # Zed's dead, baby
         end
+
+
         @out_thread.kill
-        @write_io.close
-        @read_io.close
+        begin
+          @write_io.close
+          @read_io.close
+        rescue Exception => e
+          puts "Got an exception!"
+          puts e.message
+          puts e.backtrace
+        end
         ObjectSpace.undefine_finalizer(self)
         @pid = nil
       end


### PR DESCRIPTION
On Jruby there seems to be a race condition that causes
$! to be set but no exception thrown. Putting this inside a begin
seems to fix this.

This becomes an issue because simplecov uses $! to detect if there was an exception thrown during a test run and it returns an exit code of 1 which fails the build. This only happens on Jruby (I can't reproduce this on MRI and didn't try any other versions).

I'm not really sure why $! is set but no exception is thrown, but it was always happening on the @read_io.close and contained a stream closed exception.

Let me know if you need more information or want me to change anything.
