### PR TITLE
Add :pdf to acceptable format of `save_screenshot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ any valid element selector to make a screenshot bounded by that element
 If you need for some reasons base64 encoded screenshot you can simply call
 `render_base64` that will return you encoded image. Additional options are the
 same as for `save_screenshot` except the first argument which is format (:png by
-default, acceptable :png, :gif, :jpeg).
+default, acceptable :png, :gif, :jpeg and :pdf).
 
 ### Resizing the window ###
 


### PR DESCRIPTION
The PDF format is supported by phantomjs.
- http://phantomjs.org/api/webpage/method/render.html
