### PR TITLE
Make node#set work for select elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 *   Fix JRuby support when PhantomJS quits first  [Issue #382, #404]
 *   Fix ability to pass element to `within_frame`  [Issue #414]
 *   Fix setting negatives in number inputs (John Hawthorn)
+*   Allow value to be set in select elements
 
 ### 1.4.1 ###
 

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -171,6 +171,8 @@ class PoltergeistAgent.Node
     @element.value = ''
     this.trigger('focus')
 
+    if @element.tagName == 'SELECT'
+      this.select(value)
     if @element.type == 'number'
       @element.value = value
     else

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -72,6 +72,8 @@ module Capybara::Poltergeist
       elsif self[:contenteditable] == 'true'
         command :delete_text
         send_keys(value.to_s)
+      else
+        command :set, value.to_s
       end
     end
 

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -128,6 +128,12 @@ describe Capybara::Session do
         expect(element.value).to eq('-100')
       end
 
+      it 'sets value in a select field' do
+        element = @session.find(:css, '#change_me_select')
+        element.set "Yolo"
+        expect(element.value).to eq("2")
+      end
+
       it 'fires the keydown event' do
         expect(@session.find(:css, '#changes_on_keydown').text).to eq("6")
       end

--- a/spec/support/views/with_js.erb
+++ b/spec/support/views/with_js.erb
@@ -38,6 +38,12 @@
       <input type="text" name="change_me_withname" id="change_me_withname">
     </p>
     <p><input type="file" name="change_me_file" id="change_me_file"></p>
+    <p>
+      <select id="change_me_select">
+        <option value="1">Default</option>
+        <option value="2">Yolo</option>
+      </select>
+    </p>
     <p id="changes"></p>
     <p id="changes_on_input"></p>
     <p id="changes_on_keydown"></p>


### PR DESCRIPTION
Capybara doesn't seem to specify exactly what should happen when you `set` a "SELECT" element but the capybara-webkit driver honors the request. This is a nice feature to have when using a page object framework like site_prism which doesn't distinguish between elements of different types and encourages you to set them all the same way.

This pull request makes poltergeist behave the same as webkit in this respect.
