### PR TITLE
Clean up fd after use

### DIFF
--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -94,12 +94,10 @@ module Capybara::Poltergeist
     def redirect_stdout
       prev = STDOUT.dup
       prev.autoclose = false
-      $stdout = @write_io
       STDOUT.reopen(@write_io)
       yield
     ensure
       STDOUT.reopen(prev)
-      $stdout = STDOUT
       prev.close unless prev.closed?
     end
 


### PR DESCRIPTION
If application is using many sessions and runs for a long time it fails with Errno::EMFile too many open files error. It is happening because STDOUT.dup creating new file descriptor, but STDOUT.reopen only reassociates fd#1 with given filepath but not removes created file descriptor.
This pr fixes the problem.
