### PR TITLE
Allow access to node attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *   Added ability to set zoom_factor (Dmytro Budnyk)
 *   Write JSON to the logger, rather than Ruby [Issue #430]
+*   Added ability to access all of a nodes attributes (Jon Rowe)
 
 #### Bug fixes ####
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -70,6 +70,10 @@ module Capybara::Poltergeist
       command 'delete_text', page_id, id
     end
 
+    def attributes(page_id, id)
+      command 'attributes', page_id, id
+    end
+
     def attribute(page_id, id, name)
       command 'attribute', page_id, id, name.to_s
     end

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -148,6 +148,12 @@ class PoltergeistAgent.Node
     window.getSelection().addRange(range)
     window.getSelection().deleteFromDocument()
 
+  getAttributes: ->
+    attrs = {}
+    for attr, i in @element.attributes
+      attrs[attr.name] = attr.value.replace("\n","\\n");
+    attrs
+
   getAttribute: (name) ->
     if name == 'checked' || name == 'selected'
       @element[name]

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -127,6 +127,9 @@ class Poltergeist.Browser
   attribute: (page_id, id, name) ->
     this.sendResponse this.node(page_id, id).getAttribute(name)
 
+  attributes: (page_id, id, name) ->
+    this.sendResponse this.node(page_id, id).getAttributes()
+
   value: (page_id, id) ->
     this.sendResponse this.node(page_id, id).value()
 

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -243,6 +243,17 @@ PoltergeistAgent.Node = (function() {
     return window.getSelection().deleteFromDocument();
   };
 
+  Node.prototype.getAttributes = function() {
+    var attr, attrs, i, _i, _len, _ref;
+    attrs = {};
+    _ref = this.element.attributes;
+    for (i = _i = 0, _len = _ref.length; _i < _len; i = ++_i) {
+      attr = _ref[i];
+      attrs[attr.name] = attr.value.replace("\n", "\\n");
+    }
+    return attrs;
+  };
+
   Node.prototype.getAttribute = function(name) {
     if (name === 'checked' || name === 'selected') {
       return this.element[name];

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -170,6 +170,10 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(this.node(page_id, id).getAttribute(name));
   };
 
+  Browser.prototype.attributes = function(page_id, id, name) {
+    return this.sendResponse(this.node(page_id, id).getAttributes());
+  };
+
   Browser.prototype.value = function(page_id, id) {
     return this.sendResponse(this.node(page_id, id).value());
   };

--- a/lib/capybara/poltergeist/client/compiled/node.js
+++ b/lib/capybara/poltergeist/client/compiled/node.js
@@ -3,7 +3,7 @@ var __slice = [].slice;
 Poltergeist.Node = (function() {
   var name, _fn, _i, _len, _ref;
 
-  Node.DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete', 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'isVisible', 'position', 'trigger', 'parentId', 'mouseEventTest', 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText'];
+  Node.DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete', 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'getAttributes', 'isVisible', 'position', 'trigger', 'parentId', 'mouseEventTest', 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText'];
 
   function Node(page, id) {
     this.page = page;

--- a/lib/capybara/poltergeist/client/node.coffee
+++ b/lib/capybara/poltergeist/client/node.coffee
@@ -2,7 +2,7 @@
 
 class Poltergeist.Node
   @DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete',
-                'removeAttribute', 'isMultiple', 'select', 'tagName', 'find',
+                'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'getAttributes',
                 'isVisible', 'position', 'trigger', 'parentId', 'mouseEventTest',
                 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText']
 

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -50,6 +50,10 @@ module Capybara::Poltergeist
       command :attribute, name
     end
 
+    def attributes
+      command :attributes
+    end
+
     def value
       command :value
     end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -576,5 +576,12 @@ describe Capybara::Session do
         expect(@session.find(:css, '#qux').text).to eq 'qux'
       end
     end
+
+    it "allows access to element attributes" do
+      @session.visit "/poltergeist/attributes"
+      expect(@session.find(:css,'#my_link').native.attributes).to eq(
+        'href' => '#', 'id' => 'my_link', 'class' => 'some_class', 'data' => 'rah!'
+      )
+    end
   end
 end

--- a/spec/support/views/attributes.erb
+++ b/spec/support/views/attributes.erb
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <a href="#" id="my_link" class="some_class" data="rah!">Link me</a>
+  </body>
+</html>


### PR DESCRIPTION
Rather than accessing attributes one at a time, this allows access to a nodes
attributes all in one go.
