### PR TITLE
Allow easy access to a nodes parent nodes.

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -49,6 +49,10 @@ module Capybara::Poltergeist
       command 'title'
     end
 
+    def parents(page_id, id)
+      command 'parents', page_id, id
+    end
+
     def find(method, selector)
       result = command('find', method, selector)
       result['ids'].map { |id| [result['page_id'], id] }

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -83,6 +83,14 @@ class PoltergeistAgent.Node
   parentId: ->
     @agent.register(@element.parentNode)
 
+  parentIds: ->
+    ids = []
+    parent = @element.parentNode
+    while parent != document
+      ids.push @agent.register(parent)
+      parent = parent.parentNode
+    ids
+
   find: (method, selector) ->
     @agent.find(method, selector, @element)
 

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -127,6 +127,9 @@ class Poltergeist.Browser
   attribute: (page_id, id, name) ->
     this.sendResponse this.node(page_id, id).getAttribute(name)
 
+  parents: (page_id, id) ->
+    this.sendResponse this.node(page_id, id).parentIds()
+
   value: (page_id, id) ->
     this.sendResponse this.node(page_id, id).value()
 

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -157,6 +157,17 @@ PoltergeistAgent.Node = (function() {
     return this.agent.register(this.element.parentNode);
   };
 
+  Node.prototype.parentIds = function() {
+    var ids, parent;
+    ids = [];
+    parent = this.element.parentNode;
+    while (parent !== document) {
+      ids.push(this.agent.register(parent));
+      parent = parent.parentNode;
+    }
+    return ids;
+  };
+
   Node.prototype.find = function(method, selector) {
     return this.agent.find(method, selector, this.element);
   };

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -170,6 +170,10 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(this.node(page_id, id).getAttribute(name));
   };
 
+  Browser.prototype.parents = function(page_id, id) {
+    return this.sendResponse(this.node(page_id, id).parentIds());
+  };
+
   Browser.prototype.value = function(page_id, id) {
     return this.sendResponse(this.node(page_id, id).value());
   };

--- a/lib/capybara/poltergeist/client/compiled/node.js
+++ b/lib/capybara/poltergeist/client/compiled/node.js
@@ -3,7 +3,7 @@ var __slice = [].slice;
 Poltergeist.Node = (function() {
   var name, _fn, _i, _len, _ref;
 
-  Node.DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete', 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'isVisible', 'position', 'trigger', 'parentId', 'mouseEventTest', 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText'];
+  Node.DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete', 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'isVisible', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest', 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText'];
 
   function Node(page, id) {
     this.page = page;

--- a/lib/capybara/poltergeist/client/node.coffee
+++ b/lib/capybara/poltergeist/client/node.coffee
@@ -3,7 +3,7 @@
 class Poltergeist.Node
   @DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete',
                 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find',
-                'isVisible', 'position', 'trigger', 'parentId', 'mouseEventTest',
+                'isVisible', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest',
                 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText']
 
   constructor: (@page, @id) ->

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -26,6 +26,10 @@ module Capybara::Poltergeist
       end
     end
 
+    def parents
+      command(:parents).map { |parent_id| self.class.new(driver, page_id, parent_id) }
+    end
+
     def find(method, selector)
       command(:find_within, method, selector).map { |id| self.class.new(driver, page_id, id) }
     end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -576,5 +576,11 @@ describe Capybara::Session do
         expect(@session.find(:css, '#qux').text).to eq 'qux'
       end
     end
+
+    it "knows about its parents" do
+      @session.visit '/poltergeist/simple'
+      parents = @session.find(:css,'#nav').native.parents
+      expect(parents.map &:tag_name).to eq ['li','ul','body','html']
+    end
   end
 end

--- a/spec/support/views/simple.erb
+++ b/spec/support/views/simple.erb
@@ -5,6 +5,9 @@
   </head>
 
   <body>
+    <ul>
+      <li><a id="nav" href="/">Home</a></li>
+    </ul>
     <a href="/">Link</a>
 
     <p id="break">Foo<br>Bar</p>


### PR DESCRIPTION
It's slow to do this on a 3rd party side (I'm assuming because of the execution lag between ruby and JS), not to mention prone to running into ObsoleteNode errors (sometimes triggered by reaching the document when looping) so this is a way to do most of it client side.
