### PR TITLE
Protect against null result when running command

### DIFF
--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -377,20 +377,22 @@ Poltergeist.WebPage = (function() {
     result = this.evaluate(function(name, args) {
       return __poltergeist.externalCall(name, args);
     }, name, args);
-    if (result.error != null) {
-      switch (result.error.message) {
-        case 'PoltergeistAgent.ObsoleteNode':
-          throw new Poltergeist.ObsoleteNode;
-          break;
-        case 'PoltergeistAgent.InvalidSelector':
-          method = args[0], selector = args[1];
-          throw new Poltergeist.InvalidSelector(method, selector);
-          break;
-        default:
-          throw new Poltergeist.BrowserError(result.error.message, result.error.stack);
+    if (result !== null) {
+      if (result.error != null) {
+        switch (result.error.message) {
+          case 'PoltergeistAgent.ObsoleteNode':
+            throw new Poltergeist.ObsoleteNode;
+            break;
+          case 'PoltergeistAgent.InvalidSelector':
+            method = args[0], selector = args[1];
+            throw new Poltergeist.InvalidSelector(method, selector);
+            break;
+          default:
+            throw new Poltergeist.BrowserError(result.error.message, result.error.stack);
+        }
+      } else {
+        return result.value;
       }
-    } else {
-      return result.value;
     }
   };
 

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -270,17 +270,18 @@ class Poltergeist.WebPage
       name, args
     )
 
-    if result.error?
-      switch result.error.message
-        when 'PoltergeistAgent.ObsoleteNode'
-          throw new Poltergeist.ObsoleteNode
-        when 'PoltergeistAgent.InvalidSelector'
-          [method, selector] = args
-          throw new Poltergeist.InvalidSelector(method, selector)
-        else
-          throw new Poltergeist.BrowserError(result.error.message, result.error.stack)
-    else
-      result.value
+    if result != null
+      if result.error?
+        switch result.error.message
+          when 'PoltergeistAgent.ObsoleteNode'
+            throw new Poltergeist.ObsoleteNode
+          when 'PoltergeistAgent.InvalidSelector'
+            [method, selector] = args
+            throw new Poltergeist.InvalidSelector(method, selector)
+          else
+            throw new Poltergeist.BrowserError(result.error.message, result.error.stack)
+      else
+        result.value
 
   canGoBack: ->
     @native.canGoBack


### PR DESCRIPTION
In some situations (I think it's related to JS errors on the page), the result of runCommand will be null and the resulting check for an error then causes an error, this is a trivial fix up