### PR TITLE
Render full window size if document has no height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     (Pedro Carriço and Erik Ostrom) [Issue #432]
 *   Raise exception on PhantomJS "status: fail" result (i.e DNS issue) instead
     of returning minimal HTML body (Dean Holdren) [Issue #473]
+*   Render full window size when document has no height (Kevin McConnell)
 
 ### 1.5.0 ###
 

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -48,8 +48,8 @@ class PoltergeistAgent
     @elements.length - 1
 
   documentSize: ->
-    height: document.documentElement.scrollHeight,
-    width:  document.documentElement.scrollWidth
+    height: document.documentElement.scrollHeight || document.documentElement.clientHeight,
+    width:  document.documentElement.scrollWidth  || document.documentElement.clientWidth
 
   get: (id) ->
     @nodes[id] or= new PoltergeistAgent.Node(this, @elements[id])

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -89,8 +89,8 @@ PoltergeistAgent = (function() {
 
   PoltergeistAgent.prototype.documentSize = function() {
     return {
-      height: document.documentElement.scrollHeight,
-      width: document.documentElement.scrollWidth
+      height: document.documentElement.scrollHeight || document.documentElement.clientHeight,
+      width: document.documentElement.scrollWidth || document.documentElement.clientWidth
     };
   };
 

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -131,6 +131,17 @@ module Capybara::Poltergeist
         end
       end
 
+      it 'supports rendering the entire window when documentElement has no height' do
+        @session.visit('/poltergeist/fixed_positioning')
+
+        create_screenshot file, full: true
+        File.open(file, 'rb') do |f|
+          expect(ImageSize.new(f.read).size).to eq(
+            @driver.evaluate_script('[window.innerWidth, window.innerHeight]')
+          )
+        end
+      end
+
       it 'supports rendering just the selected element' do
         @session.visit('/poltergeist/long_page')
 

--- a/spec/support/views/fixed_positioning.erb
+++ b/spec/support/views/fixed_positioning.erb
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<body style="margin: 0; padding: 0;">
+  <div style="position: fixed">
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </div>
+</body>


### PR DESCRIPTION
When creating screenshots with `:full => true`, the call was failing silently (no screenshot being created) for me sometimes.  It turned out to be happening any time the document's root element had a height of zero.  This PR changes the behavior to fall back to using the viewport size in that case.

I encountered this because I'm working on a project that uses `position: fixed` for all the main content elements (which is what results in the zero height on the `html` and `body` elements).  I'm using `capybara-screenshot` to take screenshots whenever specs fail, and the result was that no screenshot files were created.

I suspect this may also be related to #209, but I don't really have a way to confirm that.
