### PR TITLE
Fix typo redirectUrl -> redirectURL

### DIFF
--- a/lib/capybara/poltergeist/network_traffic/response.rb
+++ b/lib/capybara/poltergeist/network_traffic/response.rb
@@ -21,7 +21,7 @@ module Capybara::Poltergeist::NetworkTraffic
     end
 
     def redirect_url
-      @data['redirectUrl']
+      @data['redirectURL']
     end
 
     def body_size


### PR DESCRIPTION
Is named redirectURL in web_page.coffee
