### PR TITLE
Escape line endings before attempting to convert to json

### DIFF
--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -341,7 +341,15 @@ Poltergeist.WebPage = (function() {
     var args, fn;
     fn = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
     this.injectAgent();
-    return JSON.parse(this["native"].evaluate("function() { return PoltergeistAgent.stringify(" + (this.stringifyCall(fn, args)) + ") }"));
+    return JSON.parse(this.sanitize(this["native"].evaluate("function() { return PoltergeistAgent.stringify(" + (this.stringifyCall(fn, args)) + ") }")));
+  };
+
+  WebPage.prototype.sanitize = function(potential_string) {
+    if (typeof potential_string === "string") {
+      return potential_string.replace("\n", "\\n").replace("\r", "\\r");
+    } else {
+      return potential_string;
+    }
   };
 
   WebPage.prototype.execute = function() {
@@ -377,20 +385,22 @@ Poltergeist.WebPage = (function() {
     result = this.evaluate(function(name, args) {
       return __poltergeist.externalCall(name, args);
     }, name, args);
-    if (result.error != null) {
-      switch (result.error.message) {
-        case 'PoltergeistAgent.ObsoleteNode':
-          throw new Poltergeist.ObsoleteNode;
-          break;
-        case 'PoltergeistAgent.InvalidSelector':
-          method = args[0], selector = args[1];
-          throw new Poltergeist.InvalidSelector(method, selector);
-          break;
-        default:
-          throw new Poltergeist.BrowserError(result.error.message, result.error.stack);
+    if (result !== null) {
+      if (result.error != null) {
+        switch (result.error.message) {
+          case 'PoltergeistAgent.ObsoleteNode':
+            throw new Poltergeist.ObsoleteNode;
+            break;
+          case 'PoltergeistAgent.InvalidSelector':
+            method = args[0], selector = args[1];
+            throw new Poltergeist.InvalidSelector(method, selector);
+            break;
+          default:
+            throw new Poltergeist.BrowserError(result.error.message, result.error.stack);
+        }
+      } else {
+        return result.value;
       }
-    } else {
-      return result.value;
     }
   };
 


### PR DESCRIPTION
When attempting to send back line endings PhantomJS will blow up because JSON won't parse
line ends inside object values, I attempted to write a spec for this but couldn't get the
server to serve up the right line endings, I know this is triggered by a "windows" \r\n...
