### PR TITLE
Upgrade capybara to latest minor

### DIFF
--- a/poltergeist.gemspec
+++ b/poltergeist.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'capybara',         '~> 2.1'
+  s.add_dependency 'capybara',         '~> 2.2'
   s.add_dependency 'websocket-driver', '>= 0.2.0'
   s.add_dependency 'multi_json',       '~> 1.0'
   s.add_dependency 'cliver',           '~> 0.3.1'


### PR DESCRIPTION
There are no breaking changes in 2.2 only added api features and bug
fixes. The upgrade should be safe assuming good test coverage over
existing capybara api features.

I didn't include a changelog entry because I wasn't sure if you'd release it independently or with other changes.

Ref: https://github.com/jnicklas/capybara/blob/master/History.md
