### PR TITLE
Respect `Capybara.save_and_open_page_path` when saving screenshot

### DIFF
--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -153,6 +153,11 @@ module Capybara::Poltergeist
     end
 
     def save_screenshot(path, options = {})
+      if Capybara.save_and_open_page_path
+        path = File.expand_path(path, Capybara.save_and_open_page_path)
+        FileUtils.mkdir_p(File.dirname(path))
+      end
+
       browser.render(path, options)
     end
     alias_method :render, :save_screenshot

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -188,6 +188,25 @@ module Capybara::Poltergeist
         expect(File.exist?(file)).to be_true
       end
 
+      it 'renders to Capybara.save_and_open_page_path without path' do
+        @session.visit('/')
+
+        original_path = Capybara.save_and_open_page_path
+
+        Capybara.save_and_open_page_path = File.dirname(file)
+
+        FileUtils.rm_f file
+        @driver.save_screenshot(File.basename(file))
+        expect(File.exist?(file)).to be_true
+
+        Capybara.save_and_open_page_path = POLTERGEIST_ROOT
+
+        FileUtils.rm_f file
+        @driver.save_screenshot(file)
+        expect(File.exist?(file)).to be_true
+
+        Capybara.save_and_open_page_path = original_path
+      end
 
       shared_examples 'when #zoom_factor= is set' do
         let(:format) {:xbm}


### PR DESCRIPTION
Capybara uses `Capybara.save_and_open_page_path` configuration option
to set default path where pages are saved when `save_page` is called. So
if `save_page` is called with the file name only (without path), capybara
saves page into this path. Default value of this option for Rails
application is `Rails.root.join('tmp/capybara')`.

This commit changes poltergeist `save_screenshot` method to respect this
option and thus behave the same as Capybara's `save_page`.

Behaviour before this commit for Rails application (with default value of
`Capybara.save_and_open_page_path`):

```
save_page('page1.html')       # saved to RAILS_ROOT/tmp/capybara/page1.html
save_screenshot('page1.png')  # saved to RAILS_ROOT/page1.png
```

Behaviour after this commit for Rails application (with default value of
`Capybara.save_and_open_page_path`):

```
save_page('page1.html')       # saved to RAILS_ROOT/tmp/capybara/page1.html
save_screenshot('page1.png')  # saved to RAILS_ROOT/tmp/capybara/page1.png
```
