### PR TITLE
Handle 'status: fail' responses from PhantomJS land instead of returning minimal HTML (i.e. "blank page")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 *   Fix `set` appending to `contenteditable` instead of replacing its text
     (Pedro Carriço and Erik Ostrom) [Issue #432]
+*   Raise exception on PhantomJS "status: fail" result (i.e DNS issue) instead
+    of returning minimal HTML body (Dean Holdren) [Issue #473]
 
 ### 1.5.0 ###
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -7,7 +7,8 @@ module Capybara::Poltergeist
     ERROR_MAPPINGS = {
       "Poltergeist.JavascriptError" => JavascriptError,
       "Poltergeist.FrameNotFound"   => FrameNotFound,
-      "Poltergeist.InvalidSelector" => InvalidSelector
+      "Poltergeist.InvalidSelector" => InvalidSelector,
+      "Poltergeist.StatusFailError" => StatusFailError
     }
 
     attr_reader :server, :client, :logger

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -66,6 +66,8 @@ class Poltergeist.Browser
 
     if errors.length > 0 && @js_errors
       @owner.sendError(new Poltergeist.JavascriptError(errors))
+    else if @page.statusCode() == null && response? && response['status'] == 'fail'
+      @owner.sendError(new Poltergeist.StatusFailError)
     else
       @owner.sendResponse(response)
 

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -94,6 +94,8 @@ Poltergeist.Browser = (function() {
     this.page.clearErrors();
     if (errors.length > 0 && this.js_errors) {
       return this.owner.sendError(new Poltergeist.JavascriptError(errors));
+    } else if (this.page.statusCode() === null && (response != null) && response['status'] === 'fail') {
+      return this.owner.sendError(new Poltergeist.StatusFailError);
     } else {
       return this.owner.sendResponse(response);
     }

--- a/lib/capybara/poltergeist/client/compiled/main.js
+++ b/lib/capybara/poltergeist/client/compiled/main.js
@@ -174,6 +174,23 @@ Poltergeist.BrowserError = (function(_super) {
 
 })(Poltergeist.Error);
 
+Poltergeist.StatusFailError = (function(_super) {
+  __extends(StatusFailError, _super);
+
+  function StatusFailError() {
+    return StatusFailError.__super__.constructor.apply(this, arguments);
+  }
+
+  StatusFailError.prototype.name = "Poltergeist.StatusFailError";
+
+  StatusFailError.prototype.args = function() {
+    return [];
+  };
+
+  return StatusFailError;
+
+})(Poltergeist.Error);
+
 phantom.injectJs("" + phantom.libraryPath + "/web_page.js");
 
 phantom.injectJs("" + phantom.libraryPath + "/node.js");

--- a/lib/capybara/poltergeist/client/main.coffee
+++ b/lib/capybara/poltergeist/client/main.coffee
@@ -75,6 +75,10 @@ class Poltergeist.BrowserError extends Poltergeist.Error
   name: "Poltergeist.BrowserError"
   args: -> [@message, @stack]
 
+class Poltergeist.StatusFailError extends Poltergeist.Error
+  name: "Poltergeist.StatusFailError"
+  args: -> []
+
 # We're using phantom.libraryPath so that any stack traces
 # report the full path.
 phantom.injectJs("#{phantom.libraryPath}/web_page.js")

--- a/lib/capybara/poltergeist/errors.rb
+++ b/lib/capybara/poltergeist/errors.rb
@@ -54,6 +54,12 @@ module Capybara
       end
     end
 
+    class StatusFailError < ClientError
+      def message
+        "Request failed to reach server, check DNS and/or server status"
+      end
+    end
+
     class FrameNotFound < ClientError
       def name
         response['args'].first

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -480,6 +480,26 @@ module Capybara::Poltergeist
       end
     end
 
+    context "phantomjs {'status': 'fail'} responses" do
+      before { @port = @session.server.port }
+      it "Do not occur when DNS correct" do
+        expect { @session.visit("http://localhost:#{@port}/") }.not_to raise_error
+      end
+
+      it "Should handle when DNS incorrect" do
+        expect { @session.visit("http://nope:#{@port}/") }.to raise_error(StatusFailError)
+      end
+      it "Should have a descriptive message when DNS incorrect" do
+        begin
+          @session.visit("http://nope:#{@port}/")
+        rescue StatusFailError => e
+          expect(e.message).to include("Request failed to reach server, check DNS and/or server status")
+        else
+          raise "expected StatusFailError"
+        end
+      end
+    end
+
     context "network traffic" do
       before do
         @driver.restart


### PR DESCRIPTION
## Problem:
### When there is a DNS issue, or the server is down, Poltergeist will return a body like this:

``` html
<html><head></head><body></body></html>
```

In your capybara tests then, you will get `Unable to find field "foo" (Capybara::ElementNotFound)` when the actual problem is 
a) your host name is unusable (i.e. what you set for Capybara.default_host or Capybara.app_host is not in /etc/hosts) 
b) the server died somehow
## Solution:
### Detect a PhantomJS "fail" status.

When PhantomJS can't reach a server, it returns an actionable "status" value, and, oddly, a minimal HTML structure for page.body.  Poltergeist should detect the status and raise an Error.

``` js
var page = require('webpage').create();

var url = "http://nope";

page.onResourceReceived = function(resource) {
    console.log('Url: ' + resource.url);
    console.log('Code: ' + resource.status);
}

page.open(url, function(status) {
  console.log('Status: ' + JSON.stringify(status));
  console.log('Page: '+JSON.stringify(page));
  phantom.exit();
});
```

```
Url: http://nope/
Code: null
Status: "fail"
Page: {
  "objectName": "WebPage",
  "title": "",
  "frameTitle": "",
  "content": "<html><head></head><body></body></html>",
  "frameContent": "<html><head></head><body></body></html>",
  "url": "about:blank",
  "frameUrl": "about:blank",
  "loading": false,
  "loadingProgress": 100,
  "canGoBack": false,
  "canGoForward": false,
  "plainText": "",
  "framePlainText": "",
  "libraryPath": "/Users/dholdren/tmp",
  "offlineStoragePath": "/Users/dholdren/Library/Application Support/Ofi Labs/PhantomJS",
  "offlineStorageQuota": 5242880,
  "viewportSize": {
    "height": 300,
    "width": 400
  },
  "paperSize": {},
  "clipRect": {
    "height": 0,
    "left": 0,
    "top": 0,
    "width": 0
  },
  "scrollPosition": {
    "left": 0,
    "top": 0
  },
  "navigationLocked": false,
  "customHeaders": {},
  "zoomFactor": 1,
  "cookies": [],
  "windowName": "",
  "pages": [],
  "pagesWindowName": [],
  "ownsPages": true,
  "framesName": [],
  "frameName": "",
  "framesCount": 0,
  "focusedFrameName": ""
}
```

For a comparison of a "fail" vs. a "success" in PhantomJS:
https://gist.github.com/dholdren/9942454
