### PR TITLE
use protocol-relative URL to stop warnings on https pages

### DIFF
--- a/lib/capybara/poltergeist/inspector.rb
+++ b/lib/capybara/poltergeist/inspector.rb
@@ -19,7 +19,7 @@ module Capybara::Poltergeist
     end
 
     def url
-      "http://localhost:#{port}/"
+      "//localhost:#{port}/"
     end
 
     def open

--- a/spec/unit/inspector_spec.rb
+++ b/spec/unit/inspector_spec.rb
@@ -14,12 +14,12 @@ module Capybara::Poltergeist
 
     it 'has a url' do
       subject = Inspector.new(nil, 1234)
-      expect(subject.url).to eq("http://localhost:1234/")
+      expect(subject.url).to eq("//localhost:1234/")
     end
 
     it 'can be opened' do
       subject = Inspector.new('chromium', 1234)
-      Process.should_receive(:spawn).with("chromium", "http://localhost:1234/")
+      Process.should_receive(:spawn).with("chromium", "//localhost:1234/")
       subject.open
     end
 


### PR DESCRIPTION
Running poltergeist on https: pages, "The page <path>.html ran insecure content" warnings are displayed. This patch enables poltergeist to use protocol-relative URL to stop the warnings.
