### PR TITLE
Ensure exit code is propagated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 *   Render full window size when document has no height (Kevin McConnell)
 *   Don't alter focus with send_keys if we're already in the target element
     (Adam Prescott) [Issue #493]
+*   Ensure process exits with correct status code and $! is propagated.
+    (Micah Geisel) [Issue #497]
 
 ### 1.5.0 ###
 

--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -41,7 +41,13 @@ module Capybara::Poltergeist
       @phantomjs_logger  = options[:phantomjs_logger]  || $stdout
 
       pid = Process.pid
-      at_exit { stop if Process.pid == pid }
+      at_exit do
+        # do the work in a separate thread, to avoid stomping on $!,
+        # since other libraries depend on it directly.
+        Thread.new do
+          stop if Process.pid == pid
+        end.join
+      end
     end
 
     def start


### PR DESCRIPTION
If `stop` raises and rescues an exception, $! becomes nil. Seemingly impossible
to reproduce in a unit test. For more information, see
https://github.com/teampoltergeist/poltergeist/issues/497

Fixes #497.
