### PR TITLE
Speed up travis runtime.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rvm:
   - 1.9.3
   - rbx-2
   - jruby-19mode
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true


### PR DESCRIPTION
Vast majority of time is in bundle install, and the vast majority of
that is installing nokogiri. Parallelize bundle install, and use system
libraries for nokogiri installation.