### PR TITLE
Don't permit capybara 2.3 on our 1.5 support branch

### DIFF
--- a/poltergeist.gemspec
+++ b/poltergeist.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'capybara',         '~> 2.1'
+  s.add_dependency 'capybara',         '~> 2.1', '< 2.3'
   s.add_dependency 'websocket-driver', '>= 0.2.0'
   s.add_dependency 'multi_json',       '~> 1.0'
   s.add_dependency 'cliver',           '~> 0.3.1'


### PR DESCRIPTION
The specs in capybara 2.3 require the 'launchy' gem which as of the 1.5
line of poltergeist is not a dev dependency. I guess it will be added
soon in master but since 2.3 capybara came out, poltergeist v1.5 no
longer passes it's tests.

I also noticed when running the tests that the compiled '.js' files
are different to what has been checked in. Does that mean someone
forgot to check them in along with the 1.5 release or am I doing
something wrong. I decided to leave the generated files out of this
PR for now but can add them in if you like.
