### PR TITLE
Fix find_modal (and accept_modal) to work with nested dismiss_confirm/accept_alert calls.

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -351,8 +351,8 @@ module Capybara::Poltergeist
       command 'set_prompt_response', nil
     end
 
-    def modal_messages
-      command 'modal_messages'
+    def shift_modal_message
+      command 'shift_modal_message'
     end
 
     private

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -436,6 +436,6 @@ class Poltergeist.Browser
     @prompt_responses.push response
     @sendResponse(true)
 
-  modal_messages: ->
-    @sendResponse(@processed_modal_messages)
-    @processed_modal_messages = []
+  shift_modal_message: ->
+    message = @processed_modal_messages.shift()
+    @sendResponse(message)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -590,9 +590,9 @@ Poltergeist.Browser = (function() {
     return this.sendResponse(true);
   };
 
-  Browser.prototype.modal_messages = function() {
-    this.sendResponse(this.processed_modal_messages);
-    return this.processed_modal_messages = [];
+  Browser.prototype.shift_modal_message = function() {
+    var message = this.processed_modal_messages.shift();
+    return this.sendResponse(message);
   };
 
   return Browser;

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -329,16 +329,16 @@ module Capybara::Poltergeist
       not_found_msg += " with #{expect_text}" if expect_text
 
       begin
-        modals = browser.modal_messages
-        raise Capybara::ModalNotFound if modals.empty?
-        raise Capybara::ModalNotFound if (expect_text && !modals.include?(expect_text))
+        message = browser.shift_modal_message
+        raise Capybara::ModalNotFound if message.nil?
+        raise Capybara::ModalNotFound if (expect_text && message != expect_text)
       rescue Capybara::ModalNotFound => e
         raise e, not_found_msg if (Time.now - start_time) >= timeout_sec
         sleep(0.05)
         retry
       end
 
-      modals.first
+      message
     end
   end
 end


### PR DESCRIPTION
I use code like this:
```coffeescript
$(".delete").on "click", ->
  confirmation = prompt "Are you sure you want to delete the page?", 'Type "delete" (without quotes) to confirm'
  confirmed = confirmation == "delete"

  alert "The page will not be deleted." unless confirmed

  confirmed
```

With test code like this:
```ruby
page.accept_alert do
  page.dismiss_prompt do
    page.click_button "Delete"
  end
end
```

This works in Selenium, but Poltergeist would clear the `@processed_modal_messages` array when `#dismiss_prompt` finishes, leaving no modal for `#accept_alert` to find.