### PR TITLE
Loosen phantom version. Allow 2.0

### DIFF
--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -5,7 +5,7 @@ require 'cliver'
 module Capybara::Poltergeist
   class Client
     PHANTOMJS_SCRIPT  = File.expand_path('../client/compiled/main.js', __FILE__)
-    PHANTOMJS_VERSION = ['~> 1.8','>= 1.8.1']
+    PHANTOMJS_VERSION = ['>= 1.8.1', '< 3.0']
     PHANTOMJS_NAME    = 'phantomjs'
 
     KILL_TIMEOUT = 2 # seconds


### PR DESCRIPTION
Since PhantomJS 2.0 is hopefully right around the corner, this adds support to poltergeist. I will likely be submitting additional PRs to directly support 2.0 (seeing a lot of test failures).

Fixes #535.
