### PR TITLE
Add --ssl-protocol=any to default PhantomJS options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 *   Close dup'ed fd after using (Dmitry Vorotilin) [Issue #446, #529, #528]
 *   Clean up localStorage between tests (Dmitry Vorotilin) [Issue #525]
 *   Fix double encoded current_url [Issue #418]
+*   Default to `--ssl-protocol=any` in PhantomJS so that sites without SSLv3 still work [Issue #544]
 
 ### 1.5.1 ###
 

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -49,6 +49,12 @@ module Capybara::Poltergeist
 
     def phantomjs_options
       list = options[:phantomjs_options] || []
+
+      # PhantomJS defaults to only using SSLv3, which since POODLE (Oct 2014)
+      # many sites have dropped from their supported protocols (eg PayPal,
+      # Braintree).
+      list += ["--ssl-protocol=any"] unless list.grep(/ssl-protocol/).any?
+
       list += ["--remote-debugger-port=#{inspector.port}", "--remote-debugger-autorun=yes"] if inspector
       list
     end
@@ -162,7 +168,7 @@ module Capybara::Poltergeist
     def within_window(name, &block)
       browser.within_window(name, &block)
     end
- 
+
     def no_such_window_error
       NoSuchWindowError
     end

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -12,6 +12,26 @@ module Capybara::Poltergeist
       it 'has no inspector' do
         expect(subject.inspector).to be_nil
       end
+
+      it 'adds --ssl-protocol=any to driver options' do
+        expect(subject.phantomjs_options).to eq(%w{--ssl-protocol=any})
+      end
+    end
+
+    context 'with a phantomjs_options option' do
+      subject { Driver.new(nil, phantomjs_options: %w{--hello})}
+
+      it "is a combination of ssl-protocol and the provided options" do
+        expect(subject.phantomjs_options).to eq(%w{--hello --ssl-protocol=any})
+      end
+    end
+
+    context 'with phantomjs_options containing ssl-protocol' do
+      subject { Driver.new(nil, phantomjs_options: %w{--ssl-protocol=tlsv1})}
+
+      it "uses the provided ssl-protocol" do
+        expect(subject.phantomjs_options).to eq(%w{--ssl-protocol=tlsv1})
+      end
     end
 
     context 'with a :logger option' do


### PR DESCRIPTION
PhantomJS defaults to only using SSLv3, which since POODLE (Oct 2014)
many sites have dropped from their supported protocols (eg PayPal,
Braintree).

Fixes issue #544 
