### PR TITLE
Fix for Issue 564: Persist Browser state on Ruby side

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -24,7 +24,9 @@ module Capybara::Poltergeist
       server.restart
       client.restart
 
-      self.debug = @debug if @debug
+      self.debug = @debug if defined?(@debug)
+      self.js_errors = @js_errors if defined?(@js_errors)
+      self.extensions = @extensions if @extensions
     end
 
     def visit(url)
@@ -291,10 +293,12 @@ module Capybara::Poltergeist
     end
 
     def js_errors=(val)
+      @js_errors = val
       command 'set_js_errors', !!val
     end
 
     def extensions=(names)
+      @extensions = names
       Array(names).each do |name|
         command 'add_extension', name
       end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -487,6 +487,19 @@ module Capybara::Poltergeist
           driver.quit if driver
         end
       end
+      
+      it 'does not propagate a Javascript error to ruby if error raising disabled and client restarted' do
+        begin
+          driver = Capybara::Poltergeist::Driver.new(@session.app, js_errors: false, logger: TestSessions.logger)
+          driver.restart
+          driver.visit session_url('/poltergeist/js_error')
+          driver.execute_script 'setTimeout(function() { omg }, 0)'
+          sleep 0.1
+          expect(driver.body).to include('hello')
+        ensure
+          driver.quit if driver
+        end
+      end
     end
 
     context "phantomjs {'status': 'fail'} responses" do


### PR DESCRIPTION
This is the fix for #564, in which the mutable state set on the Browser was not persisted on the Ruby side and reset after a client restart.

It looks like this issue was discovered and fixed for 'debug' already but 'js_errors' and 'extensions' remained.

This seems like a mildly brittle strategy as every piece of mutable state (setter) on the Browser needs to be handled this way going forward, but I couldn't think of a way to make it happen 'magically' without moving a lot of restart logic to the Driver or winning the Terrible Metaprogramming Olympic Games.