### PR TITLE
find command may not return what is expected

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -57,7 +57,11 @@ module Capybara::Poltergeist
 
     def find(method, selector)
       result = command('find', method, selector)
-      result['ids'].map { |id| [result['page_id'], id] }
+      if result.respond_to?(:[]) #If we reset the driver before it connects, we may not get an array
+        result['ids'].map { |id| [result['page_id'], id] }
+      else
+        []
+      end
     end
 
     def find_within(page_id, id, method, selector)


### PR DESCRIPTION

I've discovered this problem in my worker process which uses Capybara and Poltergeist
This process is checking a live website, it log-in and then check a couple of pages.  Then will sleep and do it again.
I wanted to delete the cookies so I was doing Capybara.reset! and that got me this error:
```
…/poltergeist-1.5.1/lib/capybara/poltergeist/browser.rb:  54:in `find'
…s/poltergeist-1.5.1/lib/capybara/poltergeist/driver.rb: 114:in `find'
…s/poltergeist-1.5.1/lib/capybara/poltergeist/driver.rb: 118:in `find_xpath'
…by/2.1.0/gems/capybara-2.4.4/lib/capybara/node/base.rb: 107:in `find_xpath'
…e/ruby/2.1.0/gems/capybara-2.4.4/lib/capybara/query.rb: 110:in `block in resolve_for'
…by/2.1.0/gems/capybara-2.4.4/lib/capybara/node/base.rb:  80:in `synchronize'
…e/ruby/2.1.0/gems/capybara-2.4.4/lib/capybara/query.rb: 106:in `resolve_for'
….1.0/gems/capybara-2.4.4/lib/capybara/node/matchers.rb: 122:in `block in assert_no_selector'
…by/2.1.0/gems/capybara-2.4.4/lib/capybara/node/base.rb:  84:in `synchronize'
….1.0/gems/capybara-2.4.4/lib/capybara/node/matchers.rb: 121:in `assert_no_selector'
…ruby/2.1.0/gems/capybara-2.4.4/lib/capybara/session.rb: 676:in `block (2 levels) in <class:Session>'
…ruby/2.1.0/gems/capybara-2.4.4/lib/capybara/session.rb: 104:in `reset!'
…dle/ruby/2.1.0/gems/capybara-2.4.4/lib/capybara/dsl.rb:  51:in `block (2 levels) in <module:DSL>'
```

It happens very occasionally.
It turns out that command('find') can return 'true' instead of an array. This patch will check if the command did indeed return an array instead of just assuming it did.


