### PR TITLE
Allow extending poltergeist JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 *   Capybara 2.3 window support (Dmitry Vorotilin)
 *   Added ability to clear all cookies with clear_cookies method (unmanbearpig)
 *   Move from `phantom.args` to `system.args` to support PhantomJS 2.0 (Filip Spiridonov) [Issue 566]
+*   Allow extending poltergeist JS with driver option `poltergeist_extensions`
 
 #### Bug fixes ####
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ end
     to be passed to PhantomJS, e.g. `['--load-images=no', '--ignore-ssl-errors=yes']`
 *   `:extensions` (Array) - An array of JS files to be preloaded into
     the phantomjs browser. Useful for faking unsupported APIs.
+*   `:poltergeist_extensions` (Array) - An array of JS files to be preloaded into
+    the phantomjs environment. Useful for extending poltergeist.
 *   `:port` (Fixnum) - The port which should be used to communicate
     with the PhantomJS process. Defaults to a random open port.
 

--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -29,7 +29,8 @@ module Capybara::Poltergeist
       end
     end
 
-    attr_reader :pid, :server, :path, :window_size, :phantomjs_options
+    attr_reader :pid, :server, :path, :window_size, :phantomjs_options,
+      :poltergeist_extensions
 
     def initialize(server, options = {})
       @server            = server
@@ -39,6 +40,7 @@ module Capybara::Poltergeist
       @window_size       = options[:window_size]       || [1024, 768]
       @phantomjs_options = options[:phantomjs_options] || []
       @phantomjs_logger  = options[:phantomjs_logger]  || $stdout
+      @poltergeist_extensions = options[:poltergeist_extensions] || []
 
       pid = Process.pid
       at_exit do
@@ -85,6 +87,7 @@ module Capybara::Poltergeist
       parts = [path]
       parts.concat phantomjs_options
       parts << PHANTOMJS_SCRIPT
+      parts.concat poltergeist_extensions
       parts << server.port
       parts.concat window_size
       parts

--- a/lib/capybara/poltergeist/client/compiled/main.js
+++ b/lib/capybara/poltergeist/client/compiled/main.js
@@ -1,4 +1,4 @@
-var Poltergeist, system,
+var Poltergeist, arg, args, system, _i, _len, _ref,
   __hasProp = {}.hasOwnProperty,
   __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -218,4 +218,16 @@ phantom.injectJs("" + phantom.libraryPath + "/browser.js");
 
 system = require('system');
 
-new Poltergeist(system.args[1], system.args[2], system.args[3]);
+args = [];
+
+_ref = system.args.slice(1);
+for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+  arg = _ref[_i];
+  if (/.js$/.test(arg)) {
+    phantom.injectJs(arg);
+  } else {
+    args.push(arg);
+  }
+}
+
+new Poltergeist(args[0], args[1], args[2]);

--- a/lib/capybara/poltergeist/client/main.coffee
+++ b/lib/capybara/poltergeist/client/main.coffee
@@ -91,4 +91,11 @@ phantom.injectJs("#{phantom.libraryPath}/connection.js")
 phantom.injectJs("#{phantom.libraryPath}/browser.js")
 
 system = require 'system'
-new Poltergeist(system.args[1], system.args[2], system.args[3])
+args = []
+for arg in system.args.slice(1)
+  if /.js$/.test(arg)
+    phantom.injectJs(arg)
+  else
+    args.push(arg)
+
+new Poltergeist(args[0], args[1], args[2])

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -43,7 +43,8 @@ module Capybara::Poltergeist
         :path              => options[:phantomjs],
         :window_size       => options[:window_size],
         :phantomjs_options => phantomjs_options,
-        :phantomjs_logger  => phantomjs_logger
+        :phantomjs_logger  => phantomjs_logger,
+        :poltergeist_extensions => options[:poltergeist_extensions]
       )
     end
 

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -387,6 +387,29 @@ module Capybara::Poltergeist
       end
     end
 
+    context 'extending poltergeist javascript' do
+      before do
+        @extended_driver = Capybara::Poltergeist::Driver.new(
+          @session.app,
+          logger: TestSessions.logger,
+          inspector: ENV['DEBUG'] != nil,
+          poltergeist_extensions: %W% #{File.expand_path '../../support/abort_requests.js', __FILE__ } %
+        )
+      end
+
+      it 'supports extending the poltergesit world' do
+        begin
+          @extended_driver.visit(session_url('/poltergeist/with_js'))
+          expect(@extended_driver.network_traffic.length).to eq(4)
+          response_lengths = @extended_driver.network_traffic.
+            map {|n| n.response_parts.length }
+          expect(response_lengths).to eq([2,2,2,1])
+        ensure
+          @extended_driver.quit
+        end
+      end
+    end
+
     context 'extending browser javascript' do
       before do
         @extended_driver = Capybara::Poltergeist::Driver.new(

--- a/spec/support/abort_requests.js
+++ b/spec/support/abort_requests.js
@@ -1,0 +1,8 @@
+// abort all requests to test.js
+orig = Poltergeist.WebPage.prototype.onResourceRequestedNative;
+Poltergeist.WebPage.prototype.onResourceRequestedNative = function(data,request) {
+  if (/test.js/.test(data.url)) {
+    request.abort();
+  }
+  return orig.apply(this,[data, request]);
+};


### PR DESCRIPTION
I had the problem several times, that something was missing in the Poltergeist JS world and could not extend the poltergeist JS with my own javascripts.

With the new option poltergeist_extensions you can add custom JS that can extend the poltergeist classes.

See: spec/support/abort_requests.js for an example.

I would be happy if you can merge this, or tell me what I have to change to permit merg.

Thanks a lot!

F. Pellanda