### PR TITLE
Do not encode decode url's

### DIFF
--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -25,7 +25,7 @@ class PoltergeistAgent
         throw error
 
   currentUrl: ->
-    encodeURI(decodeURI(window.location.href))
+    window.location.href
 
   find: (method, selector, within = document) ->
     try
@@ -257,7 +257,7 @@ class PoltergeistAgent.Node
       rect  = win.frameElement.getClientRects()[0]
       style = win.getComputedStyle(win.frameElement)
       win   = win.parent
-      
+
       offset.top  += rect.top + parseInt(style.getPropertyValue("padding-top"), 10)
       offset.left += rect.left + parseInt(style.getPropertyValue("padding-left"), 10)
 

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -44,7 +44,7 @@ PoltergeistAgent = (function() {
   };
 
   PoltergeistAgent.prototype.currentUrl = function() {
-    return encodeURI(decodeURI(window.location.href));
+    return window.location.href;
   };
 
   PoltergeistAgent.prototype.find = function(method, selector, within) {


### PR DESCRIPTION
Fixes #418 

This fixes an issue with PhantomJS 2.0 where urls aren't correctly encoded.