### PR TITLE
Add test for date input type

### DIFF
--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -894,7 +894,17 @@ module Capybara::Poltergeist
         input.set('replacement text')
 
         expect(input.text).to eq('replacement text')
+    end
+
+    context 'date_fields' do
+      before { @session.visit('/poltergeist/date_fields') }
+
+      it 'sets a date' do
+        input = @session.find(:css, '#date_field')
+        input.set('2016-02-14')
+        expect(input.value).to eq('2016-02-14')
       end
     end
+
   end
 end

--- a/spec/support/views/date_fields.erb
+++ b/spec/support/views/date_fields.erb
@@ -1,0 +1,10 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+  </head>
+
+  <body>
+    <input type="date" id="date_field" />
+  </body>
+</html>
+


### PR DESCRIPTION
I was originally planning to implement date input support but it already
works fine for versions 1.5.1 and 1.6.0.

Fixes teampoltergeist/poltergeist#480