### PR TITLE
Fix for Issue #420 - Add support for key modifiers for send_keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Features ####
 
+*   Add support for key modifiers for send_keys [Issue #420] (Sarah Mogin)
 *   Added ability to block resource requests (Alexander Adam & Kelvin Stinghen)
 *   Added ability to set zoom_factor (Dmytro Budnyk)
 *   Write JSON to the logger, rather than Ruby [Issue #430]

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -354,9 +354,13 @@ module Capybara::Poltergeist
       keys.map do |key|
         case key
         when Array
-          # String itself with modifiers like :alt, :shift, etc
-          raise Error, 'PhantomJS behaviour for key modifiers is currently ' \
-                       'broken, we will add this in later versions'
+          # [:Shift, "s"] => { modifier: "shift", key: "S" }   
+          # [:Ctrl, :Left] => { modifier: "ctrl", key: :Left }
+          # [:Ctrl, :Shift, :Left] => { modifier: "ctrl,shift", key: :Left }
+          letter = key.pop
+          symbol = key.map { |k| k.to_s.downcase }.join(',')
+          
+          { modifier: symbol.to_s.downcase, key: letter.capitalize }
         when Symbol
           { key: key } # Return a known sequence for PhantomJS
         when String

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -280,7 +280,13 @@ class Poltergeist.Browser
 
     for sequence in keys
       key = if sequence.key? then @currentPage.keyCode(sequence.key) else sequence
-      @currentPage.sendEvent('keypress', key)
+
+      if sequence.modifier?
+        modifier = @currentPage.keyModifierCode(sequence.modifier)
+        @currentPage.sendEvent('keypress', key, null, null, modifier)
+      else
+        @currentPage.sendEvent('keypress', key)
+
     this.sendResponse(true)
 
   render_base64: (format, full, selector = null)->

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -1,8 +1,8 @@
 var __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
 Poltergeist.Browser = (function() {
-  function Browser(owner, width, height) {
-    this.owner = owner;
+  function Browser(_at_owner, width, height) {
+    this.owner = _at_owner;
     this.width = width || 1024;
     this.height = height || 768;
     this.pages = [];
@@ -13,8 +13,7 @@ Poltergeist.Browser = (function() {
   }
 
   Browser.prototype.resetPage = function() {
-    var _ref,
-      _this = this;
+    var _ref;
     _ref = [0, []], this._counter = _ref[0], this.pages = _ref[1];
     if (this.page != null) {
       if (!this.page.closed) {
@@ -32,12 +31,14 @@ Poltergeist.Browser = (function() {
     });
     this.page.handle = "" + (this._counter++);
     this.pages.push(this.page);
-    return this.page.onPageCreated = function(newPage) {
-      var page;
-      page = new Poltergeist.WebPage(newPage);
-      page.handle = "" + (_this._counter++);
-      return _this.pages.push(page);
-    };
+    return this.page.onPageCreated = (function(_this) {
+      return function(newPage) {
+        var page;
+        page = new Poltergeist.WebPage(newPage);
+        page.handle = "" + (_this._counter++);
+        return _this.pages.push(page);
+      };
+    })(this);
   };
 
   Browser.prototype.getPageByHandle = function(handle) {
@@ -82,8 +83,7 @@ Poltergeist.Browser = (function() {
   };
 
   Browser.prototype.visit = function(url) {
-    var prevUrl,
-      _this = this;
+    var prevUrl;
     this.currentPage.state = 'loading';
     prevUrl = this.currentPage.source === null ? 'about:blank' : this.currentPage.currentUrl();
     this.currentPage.open(url);
@@ -93,15 +93,17 @@ Poltergeist.Browser = (function() {
         status: 'success'
       });
     } else {
-      return this.currentPage.waitState('default', function() {
-        if (_this.currentPage.statusCode === null && _this.currentPage.status === 'fail') {
-          return _this.owner.sendError(new Poltergeist.StatusFailError);
-        } else {
-          return _this.sendResponse({
-            status: _this.currentPage.status
-          });
-        }
-      });
+      return this.currentPage.waitState('default', (function(_this) {
+        return function() {
+          if (_this.currentPage.statusCode === null && _this.currentPage.status === 'fail') {
+            return _this.owner.sendError(new Poltergeist.StatusFailError);
+          } else {
+            return _this.sendResponse({
+              status: _this.currentPage.status
+            });
+          }
+        };
+      })(this));
     }
   };
 
@@ -208,8 +210,7 @@ Poltergeist.Browser = (function() {
   };
 
   Browser.prototype.push_frame = function(name, timeout) {
-    var _ref,
-      _this = this;
+    var _ref;
     if (timeout == null) {
       timeout = new Date().getTime() + 2000;
     }
@@ -218,17 +219,21 @@ Poltergeist.Browser = (function() {
     } else if (this.currentPage.pushFrame(name)) {
       if (this.currentPage.currentUrl() === 'about:blank') {
         this.currentPage.state = 'awaiting_frame_load';
-        return this.currentPage.waitState('default', function() {
-          return _this.sendResponse(true);
-        });
+        return this.currentPage.waitState('default', (function(_this) {
+          return function() {
+            return _this.sendResponse(true);
+          };
+        })(this));
       } else {
         return this.sendResponse(true);
       }
     } else {
       if (new Date().getTime() < timeout) {
-        return setTimeout((function() {
-          return _this.push_frame(name, timeout);
-        }), 50);
+        return setTimeout(((function(_this) {
+          return function() {
+            return _this.push_frame(name, timeout);
+          };
+        })(this)), 50);
       } else {
         return this.owner.sendError(new Poltergeist.FrameNotFound(name));
       }
@@ -261,15 +266,16 @@ Poltergeist.Browser = (function() {
   };
 
   Browser.prototype.switch_to_window = function(handle) {
-    var page,
-      _this = this;
+    var page;
     page = this.getPageByHandle(handle);
     if (page) {
       if (page !== this.currentPage) {
-        return page.waitState('default', function() {
-          _this.currentPage = page;
-          return _this.sendResponse(true);
-        });
+        return page.waitState('default', (function(_this) {
+          return function() {
+            _this.currentPage = page;
+            return _this.sendResponse(true);
+          };
+        })(this));
       } else {
         return this.sendResponse(true);
       }
@@ -295,25 +301,26 @@ Poltergeist.Browser = (function() {
   };
 
   Browser.prototype.mouse_event = function(page_id, id, name) {
-    var node,
-      _this = this;
+    var node;
     node = this.node(page_id, id);
     this.currentPage.state = 'mouse_event';
     this.last_mouse_event = node.mouseEvent(name);
-    return setTimeout(function() {
-      if (_this.currentPage.state === 'mouse_event') {
-        _this.currentPage.state = 'default';
-        return _this.sendResponse({
-          position: _this.last_mouse_event
-        });
-      } else {
-        return _this.currentPage.waitState('default', function() {
+    return setTimeout((function(_this) {
+      return function() {
+        if (_this.currentPage.state === 'mouse_event') {
+          _this.currentPage.state = 'default';
           return _this.sendResponse({
             position: _this.last_mouse_event
           });
-        });
-      }
-    }, 5);
+        } else {
+          return _this.currentPage.waitState('default', function() {
+            return _this.sendResponse({
+              position: _this.last_mouse_event
+            });
+          });
+        }
+      };
+    })(this), 5);
   };
 
   Browser.prototype.click = function(page_id, id) {
@@ -370,7 +377,7 @@ Poltergeist.Browser = (function() {
   };
 
   Browser.prototype.send_keys = function(page_id, id, keys) {
-    var key, sequence, target, _i, _len;
+    var key, modifier, sequence, target, _i, _len;
     target = this.node(page_id, id);
     if (!target.containsSelection()) {
       target.mouseEvent('click');
@@ -378,7 +385,12 @@ Poltergeist.Browser = (function() {
     for (_i = 0, _len = keys.length; _i < _len; _i++) {
       sequence = keys[_i];
       key = sequence.key != null ? this.currentPage.keyCode(sequence.key) : sequence;
-      this.currentPage.sendEvent('keypress', key);
+      if (sequence.modifier != null) {
+        modifier = this.currentPage.keyModifierCode(sequence.modifier);
+        this.currentPage.sendEvent('keypress', key, null, null, modifier);
+      } else {
+        this.currentPage.sendEvent('keypress', key);
+      }
     }
     return this.sendResponse(true);
   };
@@ -540,26 +552,28 @@ Poltergeist.Browser = (function() {
   };
 
   Browser.prototype.go_back = function() {
-    var _this = this;
     if (this.currentPage.canGoBack) {
       this.currentPage.state = 'loading';
       this.currentPage.goBack();
-      return this.currentPage.waitState('default', function() {
-        return _this.sendResponse(true);
-      });
+      return this.currentPage.waitState('default', (function(_this) {
+        return function() {
+          return _this.sendResponse(true);
+        };
+      })(this));
     } else {
       return this.sendResponse(false);
     }
   };
 
   Browser.prototype.go_forward = function() {
-    var _this = this;
     if (this.currentPage.canGoForward) {
       this.currentPage.state = 'loading';
       this.currentPage.goForward();
-      return this.currentPage.waitState('default', function() {
-        return _this.sendResponse(true);
-      });
+      return this.currentPage.waitState('default', (function(_this) {
+        return function() {
+          return _this.sendResponse(true);
+        };
+      })(this));
     } else {
       return this.sendResponse(false);
     }

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -2,8 +2,7 @@ var __slice = [].slice,
   __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
 Poltergeist.WebPage = (function() {
-  var command, delegate, _fn, _fn1, _i, _j, _len, _len1, _ref, _ref1,
-    _this = this;
+  var command, delegate, _fn, _fn1, _i, _j, _len, _len1, _ref, _ref1;
 
   WebPage.CALLBACKS = ['onAlert', 'onConsoleMessage', 'onLoadFinished', 'onInitialized', 'onLoadStarted', 'onResourceRequested', 'onResourceReceived', 'onError', 'onNavigationRequested', 'onUrlChanged', 'onPageCreated', 'onClosing'];
 
@@ -13,9 +12,9 @@ Poltergeist.WebPage = (function() {
 
   WebPage.EXTENSIONS = [];
 
-  function WebPage(_native) {
+  function WebPage(_at__native) {
     var callback, _i, _len, _ref;
-    this._native = _native;
+    this._native = _at__native;
     this._native || (this._native = require('webpage').create());
     this.id = 0;
     this.source = null;
@@ -88,8 +87,8 @@ Poltergeist.WebPage = (function() {
     return this.requestId = this.lastRequestId;
   };
 
-  WebPage.prototype.onLoadFinishedNative = function(status) {
-    this.status = status;
+  WebPage.prototype.onLoadFinishedNative = function(_at_status) {
+    this.status = _at_status;
     this.state = 'default';
     return this.source || (this.source = this._native.content);
   };
@@ -153,7 +152,7 @@ Poltergeist.WebPage = (function() {
     if (this["native"]().evaluate(function() {
       return typeof __poltergeist;
     }) === "undefined") {
-      this["native"]().injectJs("" + phantom.libraryPath + "/agent.js");
+      this["native"]().injectJs(phantom.libraryPath + "/agent.js");
       _ref2 = WebPage.EXTENSIONS;
       _results = [];
       for (_k = 0, _len2 = _ref2.length; _k < _len2; _k++) {
@@ -185,14 +184,24 @@ Poltergeist.WebPage = (function() {
     return this["native"]().event.key[name];
   };
 
+  WebPage.prototype.keyModifierCode = function(names) {
+    var modifiers;
+    modifiers = this["native"]().event.modifier;
+    names = names.split(',').map((function(name) {
+      return modifiers[name];
+    }));
+    return names[0] | names[1];
+  };
+
   WebPage.prototype.waitState = function(state, callback) {
-    var _this = this;
     if (this.state === state) {
       return callback.call();
     } else {
-      return setTimeout((function() {
-        return _this.waitState(state, callback);
-      }), 100);
+      return setTimeout(((function(_this) {
+        return function() {
+          return _this.waitState(state, callback);
+        };
+      })(this)), 100);
     }
   };
 
@@ -462,4 +471,4 @@ Poltergeist.WebPage = (function() {
 
   return WebPage;
 
-}).call(this);
+})();

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -126,6 +126,11 @@ class Poltergeist.WebPage
   keyCode: (name) ->
     this.native().event.key[name]
 
+  keyModifierCode: (names) ->
+    modifiers = this.native().event.modifier
+    names = names.split(',').map ((name) -> modifiers[name])
+    names[0] | names[1] # return codes for 1 or 2 modifiers
+
   waitState: (state, callback) ->
     if @state == state
       callback.call()

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -859,11 +859,28 @@ module Capybara::Poltergeist
         expect(input.value).to eq('Submitted')
       end
 
-      it 'raises error on modifier' do
+      it 'sends sequences with modifiers and letters' do
         input = @session.find(:css, '#empty_input')
 
-        expect { input.native.send_keys([:Shift, 's'], 'tring') }
-          .to raise_error(Capybara::Poltergeist::Error)
+        input.native.send_keys([:Shift, 's'], 't', 'r', 'i', 'n', 'g')
+
+        expect(input.value).to eq('String')
+      end
+
+      it 'sends sequences with modifiers and symbols' do
+        input = @session.find(:css, '#empty_input')
+
+        input.native.send_keys('t', 'r', 'i', 'n', 'g', [:Ctrl, :Left], 's')
+
+        expect(input.value).to eq('string')
+      end
+
+      it 'sends sequences with multiple modifiers and symbols' do
+        input = @session.find(:css, '#empty_input')
+
+        input.native.send_keys('t', 'r', 'i', 'n', 'g', [:Ctrl, :Shift, :Left], 's')
+
+        expect(input.value).to eq('s')
       end
 
       it 'has an alias' do


### PR DESCRIPTION
This is a fix for #420 that adds support for modifier keys. With this change, poltergeist should take full advantage of the sendEvent keypress functionality described at http://phantomjs.org/api/webpage/method/send-event.html.

I added spec coverage for combinations of keys with one or two modifiers:

* Shift + [letter key]
* Ctrl + Left Arrow
* Ctrl + Shift+ Left Arrow

I also confirmed the functionality by connecting this branch to a personal project with Capybara; it made my specs match my JS implementation.