### PR TITLE
Add failing spec for file uploads on phantomjs 2.0.0

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -555,6 +555,13 @@ describe Capybara::Session do
       @session.attach_file 'file', __FILE__
     end
 
+    it 'handles file uploads' do
+      @session.visit '/poltergeist/attach_file2'
+      @session.attach_file 'file', __FILE__
+      @session.click_button("submit")
+      expect(@session.body).to include("file uploaded")
+    end
+
     it 'logs mouse event co-ordinates' do
       @session.visit('/')
       @session.find(:css, 'a').click

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -73,6 +73,10 @@ class TestApp
     params['remaining_path']
   end
 
+  post '/poltergeist/fail' do
+    params['file'] ? 'file uploaded' : 'fail'
+  end
+
   protected
 
   def render_view(view)

--- a/spec/support/views/attach_file2.erb
+++ b/spec/support/views/attach_file2.erb
@@ -1,0 +1,5 @@
+<form method='post' enctype="multipart/form-data" action='/poltergeist/fail'>
+<input type="file" name='file' id="file">
+<input type='hidden' name='hidden' value='hidden'>
+<input type='submit' value='submit'>
+</form>


### PR DESCRIPTION
I am filing an issue against phantomjs for this, but relevant repro is against this code. This is a regression: spec passes on 1.9.7, but fails on 2.0.0.