### PR TITLE
Parsing Capybara.app_host for host

### DIFF
--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -244,7 +244,7 @@ module Capybara::Poltergeist
         if @started
           URI.parse(browser.current_url).host
         else
-          Capybara.app_host || "127.0.0.1"
+          URI.parse(Capybara.app_host).host || "127.0.0.1"
         end
       end
 


### PR DESCRIPTION
Capybara.app_host is defined as a full URI - http://www.example.com
which is not a valid domain for a cookie.

Extracting the host part of the Capybara.app_host solves this problem
so that cookies are written to

'www.example.com'

instead of

'http://www.example.com'

I'm a bit stuck as to how to write a spec for this, but its pretty clear that the fix is the right kind of fix to get Capybara and Poltergeist communicating clearly. This fixes the pretty rare case of when you're checking cookies for a particular URL.