### PR TITLE
Fixes "undefined method `map` for nil:NilClass" problem

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -59,7 +59,7 @@ module Capybara::Poltergeist
 
     def find(method, selector)
       result = command('find', method, selector)
-      result['ids'].map { |id| [result['page_id'], id] }
+      (result['ids'] || [0]).map { |id| [result['page_id'], id] }
     end
 
     def find_within(page_id, id, method, selector)
@@ -362,12 +362,12 @@ module Capybara::Poltergeist
       keys.map do |key|
         case key
         when Array
-          # [:Shift, "s"] => { modifier: "shift", key: "S" }   
+          # [:Shift, "s"] => { modifier: "shift", key: "S" }
           # [:Ctrl, :Left] => { modifier: "ctrl", key: :Left }
           # [:Ctrl, :Shift, :Left] => { modifier: "ctrl,shift", key: :Left }
           letter = key.pop
           symbol = key.map { |k| k.to_s.downcase }.join(',')
-          
+
           { modifier: symbol.to_s.downcase, key: letter.capitalize }
         when Symbol
           { key: key } # Return a known sequence for PhantomJS


### PR DESCRIPTION
So I was using poltergeist+cucumber, and I had the following problem.

/// 

If I run the following step, it succeeds:

``` ruby
  within_frame 'my-iframe' do
    expect(page).to have_content("CORRECT CONTENT")
  end
```

But if I run the following one, instead of the expected "expected to find text..." it throws a undefined method`map' for nil:NilClass (NoMethodError):

``` ruby
  within_frame 'my-iframe' do
    expect(page).to have_content("WRONG CONTENT")
  end
```

By inspecting the trace, it turns out it's a problem in poltergeist, where the `find` method, for some reason, doesn't get back an 'ids' key from command.

I would have added a test for this PR, but I tried running specs and got a lot of failures, also I see your build if broken. If you could help me on this would be great.
