### PR TITLE
warning: method redefined

### DIFF
--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -4,7 +4,7 @@ module Capybara::Poltergeist
   class Driver < Capybara::Driver::Base
     DEFAULT_TIMEOUT = 30
 
-    attr_reader :app, :server, :client, :browser, :options
+    attr_reader :app, :options
 
     def initialize(app, options = {})
       @app       = app


### PR DESCRIPTION
This eliminates following 3 Ruby warnings:

> warning: method redefined; discarding old browser
> warning: method redefined; discarding old server
> warning: method redefined; discarding old client