### PR TITLE
Address a handful of deprecation messages

### DIFF
--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -35,7 +35,7 @@ module Capybara::Poltergeist
           tries += 1
         end
 
-        expect(File.exist?(file)).to be_true
+        expect(File.exist?(file)).to be_truthy
       ensure
         driver.quit if driver
       end
@@ -185,7 +185,7 @@ module Capybara::Poltergeist
 
         @driver.save_screenshot(file)
 
-        expect(File.exist?(file)).to be_true
+        expect(File.exist?(file)).to be_truthy
       end
 
       it 'supports rendering the page with a nonstring path' do
@@ -194,7 +194,7 @@ module Capybara::Poltergeist
 
         @driver.save_screenshot(Pathname(file))
 
-        expect(File.exist?(file)).to be_true
+        expect(File.exist?(file)).to be_truthy
       end
 
       shared_examples 'when #zoom_factor= is set' do
@@ -487,7 +487,7 @@ module Capybara::Poltergeist
           driver.quit if driver
         end
       end
-      
+
       it 'does not propagate a Javascript error to ruby if error raising disabled and client restarted' do
         begin
           driver = Capybara::Poltergeist::Driver.new(@session.app, js_errors: false, logger: TestSessions.logger)
@@ -599,8 +599,8 @@ module Capybara::Poltergeist
         expect(cookie.value).to eq('test_cookie')
         expect(cookie.domain).to eq('127.0.0.1')
         expect(cookie.path).to eq('/')
-        expect(cookie.secure?).to be_false
-        expect(cookie.httponly?).to be_false
+        expect(cookie.secure?).to be_falsey
+        expect(cookie.httponly?).to be_falsey
         expect(cookie.expires).to be_nil
       end
 
@@ -784,7 +784,7 @@ module Capybara::Poltergeist
     context 'blacklisting urls for resource requests' do
       it 'blocks unwanted urls' do
         @driver.browser.url_blacklist = ['unwanted']
-        
+
         @session.visit '/poltergeist/url_blacklist'
 
         expect(@session.status_code).to eq(200)

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -228,7 +228,7 @@ describe Capybara::Session do
 
     it 'handles window.confirm(), returning true unconditionally' do
       @session.visit '/'
-      expect(@session.evaluate_script("window.confirm('foo')")).to be_true
+      expect(@session.evaluate_script("window.confirm('foo')")).to be_truthy
     end
 
     it 'handles window.prompt(), returning the default value or null' do
@@ -239,8 +239,8 @@ describe Capybara::Session do
 
     it 'handles evaluate_script values properly' do
       expect(@session.evaluate_script('null')).to be_nil
-      expect(@session.evaluate_script('false')).to be_false
-      expect(@session.evaluate_script('true')).to be_true
+      expect(@session.evaluate_script('false')).to be_falsey
+      expect(@session.evaluate_script('true')).to be_truthy
       expect(@session.evaluate_script("{foo: 'bar'}")).to eq({'foo' => 'bar'})
     end
 


### PR DESCRIPTION
specs aren't passing for me locally. I wanted to trigger my own Travis build so I pushed this simple PR which addresses deprecation messages for `be_true` and `be_false`. Once I get my local situation squared away I hope to contribute something a little more productive.