### PR TITLE
Address be_true & be_false deprecation warnings.

### DIFF
--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -35,7 +35,7 @@ module Capybara::Poltergeist
           tries += 1
         end
 
-        expect(File.exist?(file)).to be_true
+        expect(File.exist?(file)).to be true
       ensure
         driver.quit if driver
       end
@@ -185,7 +185,7 @@ module Capybara::Poltergeist
 
         @driver.save_screenshot(file)
 
-        expect(File.exist?(file)).to be_true
+        expect(File.exist?(file)).to be true
       end
 
       it 'supports rendering the page with a nonstring path' do
@@ -194,7 +194,7 @@ module Capybara::Poltergeist
 
         @driver.save_screenshot(Pathname(file))
 
-        expect(File.exist?(file)).to be_true
+        expect(File.exist?(file)).to be true
       end
 
       shared_examples 'when #zoom_factor= is set' do
@@ -487,7 +487,7 @@ module Capybara::Poltergeist
           driver.quit if driver
         end
       end
-      
+
       it 'does not propagate a Javascript error to ruby if error raising disabled and client restarted' do
         begin
           driver = Capybara::Poltergeist::Driver.new(@session.app, js_errors: false, logger: TestSessions.logger)
@@ -599,8 +599,8 @@ module Capybara::Poltergeist
         expect(cookie.value).to eq('test_cookie')
         expect(cookie.domain).to eq('127.0.0.1')
         expect(cookie.path).to eq('/')
-        expect(cookie.secure?).to be_false
-        expect(cookie.httponly?).to be_false
+        expect(cookie.secure?).to be false
+        expect(cookie.httponly?).to be false
         expect(cookie.expires).to be_nil
       end
 
@@ -784,7 +784,7 @@ module Capybara::Poltergeist
     context 'blacklisting urls for resource requests' do
       it 'blocks unwanted urls' do
         @driver.browser.url_blacklist = ['unwanted']
-        
+
         @session.visit '/poltergeist/url_blacklist'
 
         expect(@session.status_code).to eq(200)

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -228,7 +228,7 @@ describe Capybara::Session do
 
     it 'handles window.confirm(), returning true unconditionally' do
       @session.visit '/'
-      expect(@session.evaluate_script("window.confirm('foo')")).to be_true
+      expect(@session.evaluate_script("window.confirm('foo')")).to be true
     end
 
     it 'handles window.prompt(), returning the default value or null' do
@@ -239,8 +239,8 @@ describe Capybara::Session do
 
     it 'handles evaluate_script values properly' do
       expect(@session.evaluate_script('null')).to be_nil
-      expect(@session.evaluate_script('false')).to be_false
-      expect(@session.evaluate_script('true')).to be_true
+      expect(@session.evaluate_script('false')).to be false
+      expect(@session.evaluate_script('true')).to be true
       expect(@session.evaluate_script("{foo: 'bar'}")).to eq({'foo' => 'bar'})
     end
 


### PR DESCRIPTION
A number of deprecation warnings related to `be_true` and `be_false` are generated when running specs:
```
`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead. Called from /Users/erictheise/Projects/erictheise/poltergeist/spec/integration/session_spec.rb:242:in `block (3 levels) in <top (required)>'.
`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/erictheise/Projects/erictheise/poltergeist/spec/integration/driver_spec.rb:197:in `block (3 levels) in <module:Poltergeist>'.
Too many uses of deprecated '`be_true`'. Pass `--deprecation-out` or set `config.deprecation_stream` to a file for full output.
```
These were [deprecated in RSpec's move from 2.14 to 2.99](http://www.relishapp.com/rspec/rspec-expectations/v/2-99/docs/changelog).

Just hoping to contribute a little cleanup as I get my own local setup to pass all tests.