### PR TITLE
Close the phantomjs_logger when the driver is quit

### DIFF
--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -78,6 +78,7 @@ module Capybara::Poltergeist
     def quit
       server.stop
       client.stop
+      phantomjs_logger.close if phantomjs_logger.respond_to?(:close)
     end
 
     # logger should be an object that responds to puts, or nil


### PR DESCRIPTION
Poltergeist currently leaks open file descriptors.  This presents a problem when a single ruby process instantiates multiple capybara sessions and will eventually lead to OOM errors if hundreds/thousands of these are left open.  This commit calls #close on phantomjs_logger when the driver is quit.  