### PR TITLE
Remote debugging fixes for #579 and #654

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 *   Fire focus related events on selecting a select box option
     (Rumen Paletov) [Issue #607]
 *   Add scheme to URL passed to browser by inspector to support the "open" command [Issue #579]
+*   Support resuming from debug pause by sending a signal [Issue #654]
 
 #### Bug fixes ####
 *   Support reading text from SVG elements (Oliver Searle-Barnes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 *   Drag by offset support in native element (phoenixek12)
 *   Fire focus related events on selecting a select box option
     (Rumen Paletov) [Issue #607]
+*   Add scheme to URL passed to browser by inspector to support the "open" command [Issue #579]
 
 #### Bug fixes ####
 *   Support reading text from SVG elements (Oliver Searle-Barnes)

--- a/lib/capybara/poltergeist/inspector.rb
+++ b/lib/capybara/poltergeist/inspector.rb
@@ -22,9 +22,12 @@ module Capybara::Poltergeist
       "//localhost:#{port}/"
     end
 
-    def open
+    def open(scheme = nil)
       if browser
-        Process.spawn(browser, url)
+        scheme = 'http' unless scheme == 'https' # scheme could be 'file' or 'about' or something else
+        uri = URI.parse(url)
+        uri.scheme = scheme unless uri.scheme
+        Process.spawn(browser, uri.to_s)
       else
         raise Error, "Could not find a browser executable to open #{url}. " \
                      "You can specify one manually using e.g. `:inspector => 'chromium'` " \

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -66,6 +66,33 @@ module Capybara::Poltergeist
         expect(subject.inspector).to be_a(Inspector)
         expect(subject.inspector.browser).to eq('foo')
       end
+
+
+      it 'can pause indefinitely' do
+        expect {
+          Timeout::timeout(3) do
+            subject.pause
+          end
+        }.to raise_error(Timeout::Error)
+      end
+
+      it 'can pause and resume with keyboard input' do
+        IO.pipe() do |read_io, write_io|
+          stub_const('STDIN', read_io)
+          write_io.write "\n"
+          Timeout::timeout(3) do
+            subject.pause
+          end
+        end
+      end
+
+      it 'can pause and resume with signal' do
+        Thread.new { sleep(2); Process.kill('CONT', Process.pid); }
+        Timeout::timeout(4) do
+          subject.pause
+        end
+      end
+
     end
 
     context 'with a :timeout option' do

--- a/spec/unit/inspector_spec.rb
+++ b/spec/unit/inspector_spec.rb
@@ -19,8 +19,14 @@ module Capybara::Poltergeist
 
     it 'can be opened' do
       subject = Inspector.new('chromium', 1234)
-      Process.should_receive(:spawn).with('chromium', '//localhost:1234/')
+      Process.should_receive(:spawn).with('chromium', 'http://localhost:1234/')
       subject.open
+    end
+
+    it 'can be opened with https URL' do
+      subject = Inspector.new('chromium', 1234)
+      Process.should_receive(:spawn).with('chromium', 'https://localhost:1234/')
+      subject.open 'https'
     end
 
     it 'raises an error on open when the browser is unknown' do


### PR DESCRIPTION
Re #579, include the scheme in the URL so the `open` command will work. Considering the comment that PR #582 reverts 9b73d61, this attempts to pull the scheme from the current browser URL, so it will try to open the browser on`https` if the current page is `https`. 

Re #654, not everyone runs `poltergeist` in an environment where they can "press enter to continue." This PR adds an option to continue by sending a `SIGCONT` signal via `kill`. 