### PR TITLE
fix default_wait_time deprecation in specs

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -79,7 +79,7 @@ describe Capybara::Session do
         context 'and is then brought in' do
           before do
             @session.execute_script "$('#off-the-left').animate({left: '10'});"
-            Capybara.default_wait_time = 1 #we need capybara to retry until animation finished
+            Poltergeist::SpecHelper.set_capybara_wait_time(1)
           end
 
           it 'clicks properly' do
@@ -87,7 +87,7 @@ describe Capybara::Session do
           end
 
           after do
-            Capybara.default_wait_time = 0
+            Poltergeist::SpecHelper.set_capybara_wait_time(0)
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,18 @@ module TestSessions
   Poltergeist = Capybara::Session.new(:poltergeist, TestApp)
 end
 
+module Poltergeist
+  module SpecHelper
+    class << self
+      def set_capybara_wait_time(t)
+        Capybara.default_max_wait_time = t
+      rescue
+        Capybara.default_wait_time = t
+      end
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.before do
     TestSessions.logger.reset
@@ -41,10 +53,10 @@ RSpec.configure do |config|
   Capybara::SpecHelper.configure(config)
 
   config.before(:each) do
-    Capybara.default_wait_time = 0
+    Poltergeist::SpecHelper.set_capybara_wait_time(0)
   end
 
   config.before(:each, :requires => :js) do
-    Capybara.default_wait_time = 1
+    Poltergeist::SpecHelper.set_capybara_wait_time(1)
   end
 end


### PR DESCRIPTION
Fix the Capybara.default_wait_time deprecations shown when running specs