### PR TITLE
Fixes for #send_keys to pass Capybara specs

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -362,15 +362,15 @@ module Capybara::Poltergeist
       keys.map do |key|
         case key
         when Array
-          # [:Shift, "s"] => { modifier: "shift", key: "S" }   
+          # [:Shift, "s"] => { modifier: "shift", key: "S" }
           # [:Ctrl, :Left] => { modifier: "ctrl", key: :Left }
           # [:Ctrl, :Shift, :Left] => { modifier: "ctrl,shift", key: :Left }
           letter = key.pop
           symbol = key.map { |k| k.to_s.downcase }.join(',')
-          
+
           { modifier: symbol.to_s.downcase, key: letter.capitalize }
         when Symbol
-          { key: key } # Return a known sequence for PhantomJS
+          { key: key.capitalize } # Return a known sequence for PhantomJS
         when String
           key # Plain string, nothing to do
         end

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -284,10 +284,12 @@ class Poltergeist.Browser
 
     for sequence in keys
       key = if sequence.key? then @currentPage.keyCode(sequence.key) else sequence
-
       if sequence.modifier?
-        modifier = @currentPage.keyModifierCode(sequence.modifier)
-        @currentPage.sendEvent('keypress', key, null, null, modifier)
+        modifier_keys = @currentPage.keyModifierKeys(sequence.modifier)
+        modifier_code = @currentPage.keyModifierCode(sequence.modifier)
+        @currentPage.sendEvent('keydown', modifier_key) for modifier_key in modifier_keys
+        @currentPage.sendEvent('keypress', key, null, null, modifier_code)
+        @currentPage.sendEvent('keyup', modifier_key) for modifier_key in modifier_keys
       else
         @currentPage.sendEvent('keypress', key)
 

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -78,7 +78,7 @@ class Poltergeist.WebPage
   onResourceRequestedNative: (request, net) ->
     abort = @urlBlacklist.some (blacklisted_url) ->
       request.url.indexOf(blacklisted_url) != -1
-  
+
     if abort
       @_blockedUrls.push request.url unless request.url in @_blockedUrls
       net.abort()
@@ -130,6 +130,10 @@ class Poltergeist.WebPage
     modifiers = this.native().event.modifier
     names = names.split(',').map ((name) -> modifiers[name])
     names[0] | names[1] # return codes for 1 or 2 modifiers
+
+  keyModifierKeys: (names) ->
+    names.split(',').map (name) =>
+      this.keyCode(name.charAt(0).toUpperCase() + name.substring(1))
 
   waitState: (state, callback) ->
     if @state == state


### PR DESCRIPTION
This generates keyup/down events for modifier keys as browsers do.
It also accepts lowercase for key symbols (:Left or :left) as required by Capybara 2.5