### PR TITLE
Add request URL to StatusFailError

### DIFF
--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -103,7 +103,7 @@ class Poltergeist.Browser
       command = @current_command
       @currentPage.waitState 'default', =>
         if @currentPage.statusCode == null && @currentPage.status == 'fail'
-          command.sendError(new Poltergeist.StatusFailError)
+          command.sendError(new Poltergeist.StatusFailError(url))
         else
           command.sendResponse(status: @currentPage.status)
 

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -126,7 +126,7 @@ Poltergeist.Browser = (function() {
       return this.currentPage.waitState('default', (function(_this) {
         return function() {
           if (_this.currentPage.statusCode === null && _this.currentPage.status === 'fail') {
-            return command.sendError(new Poltergeist.StatusFailError);
+            return command.sendError(new Poltergeist.StatusFailError(url));
           } else {
             return command.sendResponse({
               status: _this.currentPage.status

--- a/lib/capybara/poltergeist/client/compiled/main.js
+++ b/lib/capybara/poltergeist/client/compiled/main.js
@@ -180,14 +180,14 @@ Poltergeist.BrowserError = (function(superClass) {
 Poltergeist.StatusFailError = (function(superClass) {
   extend(StatusFailError, superClass);
 
-  function StatusFailError() {
-    return StatusFailError.__super__.constructor.apply(this, arguments);
+  function StatusFailError(url) {
+    this.url = url;
   }
 
   StatusFailError.prototype.name = "Poltergeist.StatusFailError";
 
   StatusFailError.prototype.args = function() {
-    return [];
+    return [this.url];
   };
 
   return StatusFailError;

--- a/lib/capybara/poltergeist/client/main.coffee
+++ b/lib/capybara/poltergeist/client/main.coffee
@@ -77,8 +77,9 @@ class Poltergeist.BrowserError extends Poltergeist.Error
   args: -> [@message, @stack]
 
 class Poltergeist.StatusFailError extends Poltergeist.Error
+  constructor: (@url) ->
   name: "Poltergeist.StatusFailError"
-  args: -> []
+  args: -> [@url]
 
 class Poltergeist.NoSuchWindowError extends Poltergeist.Error
   name: "Poltergeist.NoSuchWindowError"

--- a/lib/capybara/poltergeist/errors.rb
+++ b/lib/capybara/poltergeist/errors.rb
@@ -55,8 +55,12 @@ module Capybara
     end
 
     class StatusFailError < ClientError
+      def url
+        response['args'].first
+      end
+
       def message
-        "Request failed to reach server, check DNS and/or server status"
+        "Request to '#{url}' failed to reach server, check DNS and/or server status"
       end
     end
 

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -514,10 +514,11 @@ module Capybara::Poltergeist
       end
 
       it 'has a descriptive message when DNS incorrect' do
+        url = "http://nope:#{@port}/"
         begin
-          @session.visit("http://nope:#{@port}/")
+          @session.visit(url)
         rescue StatusFailError => e
-          expect(e.message).to include('Request failed to reach server, check DNS and/or server status')
+          expect(e.message).to include("Request to '#{url}' failed to reach server, check DNS and/or server status")
         else
           raise 'expected StatusFailError'
         end


### PR DESCRIPTION
This PR adds the URL to the error message when the `visit` command fails.

When receiving this error it's often hard to figure out exactly why it happened or what URL was visited without having to add additional code or `pry` statements. I think this addition will help fix the error faster because:

- it allows the user to quickly copy/paste the URL to their own browser and check out what happens
- typo's become obvious since you can now inspect the URL
- easily tell if it's the wrong URL or something else

Example:
```
 1) Test redirect to URL
     Failure/Error: visit full_url
     Capybara::Poltergeist::StatusFailError:
       Request failed to reach server, check DNS and/or server status
```
vs
```
 1) Test redirect to URL
     Failure/Error: visit full_url
     Capybara::Poltergeist::StatusFailError:
       Request to 'http://google,com/' failed to reach server, check DNS and/or server status
```