### PR TITLE
implement driver#window_size and driver#resize_window_to from capybara

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -154,11 +154,17 @@ module Capybara::Poltergeist
       command 'close_window', handle
     end
 
-    def within_window(name, &block)
+    def find_window_handle(locator)
+      return locator if window_handles.include? locator
+
+      handle = command 'window_handle', locator
+      raise noSuchWindowError unless handle
+      return handle
+    end
+
+    def within_window(locator, &block)
       original = window_handle
-      handle = command 'window_handle', name
-      handle = name if handle.nil? && window_handles.include?(name)
-      raise NoSuchWindowError unless handle
+      handle = find_window_handle(locator)
       switch_to_window(handle)
       yield
     ensure

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -200,6 +200,18 @@ module Capybara::Poltergeist
     end
     alias_method :resize_window, :resize
 
+    def resize_window_to(handle, width, height)
+      within_window(handle) do
+        resize(width, height)
+      end
+    end
+
+    def window_size(handle)
+      within_window(handle) do
+        evaluate_script('[window.innerWidth, window.innerHeight]')
+      end
+    end
+
     def scroll_to(left, top)
       browser.scroll_to(left, top)
     end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -714,6 +714,28 @@ module Capybara::Poltergeist
       expect(@driver.window_handles).to eq(['0', '1'])
     end
 
+    it 'resizes windows' do
+      @session.visit '/'
+
+      popup1 = @session.window_opened_by do
+        @session.execute_script <<-JS
+          window.open('/poltergeist/simple', 'popup1')
+        JS
+      end
+
+      popup2 = @session.window_opened_by do
+        @session.execute_script <<-JS
+          window.open('/poltergeist/simple', 'popup2')
+        JS
+      end
+
+      popup1.resize_to(100,200)
+      popup2.resize_to(200,100)
+
+      expect(popup1.size).to eq([100,200])
+      expect(popup2.size).to eq([200,100])
+    end
+
     it 'clears local storage between tests' do
       @session.visit '/'
       @session.execute_script <<-JS


### PR DESCRIPTION
This implements 2 missing methods from driver  -- I think the only missing capybara driver method for windows now is maximize_window, which doesn't really make sense in poltergeist