### PR TITLE
Trigger focus event before element value clear

### DIFF
--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -199,8 +199,8 @@ class PoltergeistAgent.Node
     if (@element.maxLength >= 0)
       value = value.substr(0, @element.maxLength)
 
-    @element.value = ''
     this.trigger('focus')
+    @element.value = ''
 
     if @element.type == 'number'
       @element.value = value

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -314,8 +314,8 @@ PoltergeistAgent.Node = (function() {
     if (this.element.maxLength >= 0) {
       value = value.substr(0, this.element.maxLength);
     }
-    this.element.value = '';
     this.trigger('focus');
+    this.element.value = '';
     if (this.element.type === 'number') {
       this.element.value = value;
     } else {


### PR DESCRIPTION
Some JS libraries including redux-form reads element's value on `focus` event. It does not work as expected with Poltergeist because the value of the element is already updated to `''` when `focus` is triggered.

Triggering `focus` before value clear looks better simulation of user editing to me.