### PR TITLE
Consider css visibility and opacity when determining element visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 *   Fix event.target for change events on SELECT elements with OPTGROUP. (Jonathan Tron)
 *   Trigger focus before clearing element in #set. (Soutaro Matsumoto) [Issue #666]
 *   Link command and response together with an id. (Thomas Walpole) [Issue #653, #482]
+*   Consider css visibility and opacity in #visible. (Thomas Walpole) [Issue #618]
 
 ### 1.7.0 ###
 

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -246,14 +246,16 @@ class PoltergeistAgent.Node
     @element.tagName
 
   isVisible: (element) ->
-    element = @element unless element
+    element ||= @element
 
-    if window.getComputedStyle(element).display == 'none'
-      false
-    else if element.parentElement
-      this.isVisible element.parentElement
-    else
-      true
+    while (element)
+      style = window.getComputedStyle(element)
+      return false if style.display == 'none' or
+                      style.visibility == 'hidden' or
+                      parseFloat(style.opacity) == 0
+      element = element.parentElement
+
+    return true
 
   isDisabled: ->
     @element.disabled || @element.tagName == 'OPTION' && @element.parentNode.disabled

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -368,16 +368,16 @@ PoltergeistAgent.Node = (function() {
   };
 
   Node.prototype.isVisible = function(element) {
-    if (!element) {
-      element = this.element;
+    var style;
+    element || (element = this.element);
+    while (element) {
+      style = window.getComputedStyle(element);
+      if (style.display === 'none' || style.visibility === 'hidden' || parseFloat(style.opacity) === 0) {
+        return false;
+      }
+      element = element.parentElement;
     }
-    if (window.getComputedStyle(element).display === 'none') {
-      return false;
-    } else if (element.parentElement) {
-      return this.isVisible(element.parentElement);
-    } else {
-      return true;
-    }
+    return true;
   };
 
   Node.prototype.isDisabled = function() {

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -230,6 +230,24 @@ describe Capybara::Session do
       end
     end
 
+    describe 'Node#visible' do
+      before do
+        @session.visit('/poltergeist/visible')
+      end
+
+      it 'considers display: none to not be visible' do
+        expect(@session.find(:css, 'li', text: 'Display None', visible: false).visible?).to be false
+      end
+
+      it 'considers visibility: hidden to not be visible' do
+        expect(@session.find(:css, 'li', text: 'Hidden', visible: false).visible?).to be false
+      end
+
+      it 'considers opacity: 0 to not be visible' do
+        expect(@session.find(:css, 'li', text: 'Transparent', visible: false).visible?).to be false
+      end
+    end
+
     it 'has no trouble clicking elements when the size of a document changes' do
       @session.visit('/poltergeist/long_page')
       @session.find(:css, '#penultimate').click

--- a/spec/support/views/visible.erb
+++ b/spec/support/views/visible.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test</title>
+  </head>
+
+  <body>
+    <ul>
+      <li>Visible</li>
+      <li style='display: none'>Display None</li>
+      <li style='visibility: hidden'>Hidden</li>
+      <li style='opacity: 0.0'>Transparent</li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
This updates Node#visible to consider css display, visibility, and opacity when determining whether or not an element is on the screen.  This should be equivalent to what Selenium uses too.  This should fix Issue #618 