### PR TITLE
Parse hostname from Capybara.app_host when setting cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 *   Link command and response together with an id. (Thomas Walpole) [Issue #653, #482]
 *   Consider css visibility and opacity in #visible. (Thomas Walpole) [Issue #618]
 *   Enable changing to frames that have no name or id attributes. (Thomas Walpole) [Issue #630, #559]
+*   Fix domain setting of cookies when Capybara.app_host is set. (John Paul Ashenfelter, Thomas Walpole) [Issue #593]
 
 ### 1.7.0 ###
 

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -256,7 +256,7 @@ module Capybara::Poltergeist
         if @started
           URI.parse(browser.current_url).host
         else
-          Capybara.app_host || "127.0.0.1"
+          URI.parse(Capybara.app_host || '').host || "127.0.0.1"
         end
       end
 

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -675,6 +675,23 @@ module Capybara::Poltergeist
         @session.visit('/set_cookie')
         expect(@driver.cookies).to_not be_empty
       end
+
+      it 'sets cookies correctly when Capybara.app_host is set' do
+        old_app_host = Capybara.app_host
+        begin
+          Capybara.app_host = 'http://localhost/poltergeist'
+          @driver.set_cookie 'capybara', 'app_host'
+
+          port = @session.server.port
+          @session.visit("http://localhost:#{port}/poltergeist/get_cookie")
+          expect(@driver.body).to include('app_host')
+
+          @session.visit("http://127.0.0.1:#{port}/poltergeist/get_cookie")
+          expect(@driver.body).not_to include('app_host')
+        ensure
+          Capybara.app_host = old_app_host
+        end
+      end
     end
 
     it 'allows the driver to have a fixed port' do


### PR DESCRIPTION
Capybara.app_host can be a full url  - so it needs to be parsed for the hostname when using to set cookie domain.