### PR TITLE
Match selenium behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,18 @@ rvm:
   - 1.9.3
   - rbx-2
   - jruby-19mode
+gemfile:
+  - Gemfile
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 matrix:
   include:
     - rvm: 2.2.2
+      gemfile: Gemfile
       env: USE_PHANTOMJS2=true
+    - rvm: 2.2.2
+      gemfile: gemfiles/Gemfile.capybara_master
   allow_failures:
     - env: USE_PHANTOMJS2=true
+    - gemfile: gemfiles/Gemfile.capybara_master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Features ####
 *   Implement support for Capybara Window#size and Window#resize_to (Thomas Walpole)
 *   Add access to properties of node's native element (Mike Souza)
+*   Node#[] now prefers element properties over attributes when the property exists and is
+    not an object.  This is similar to the selenium driver behavior. (Thomas Walpole)
 
 #### Bug fixes ####
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features ####
 *   Implement support for Capybara Window#size and Window#resize_to (Thomas Walpole)
+*   Add access to properties of node's native element (Mike Souza)
 
 #### Bug fixes ####
 

--- a/gemfiles/Gemfile.capybara_master
+++ b/gemfiles/Gemfile.capybara_master
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+gemspec :path => '..'
+
+gem 'capybara', github: 'jnicklas/capybara'
+
+platforms :rbx do
+  gem 'rubysl'
+  gem 'racc'
+  gem 'json'
+end

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -79,6 +79,10 @@ module Capybara::Poltergeist
       command 'delete_text', page_id, id
     end
 
+    def property(page_id, id, name)
+      command 'property', page_id, id, name.to_s
+    end
+
     def attributes(page_id, id)
       command 'attributes', page_id, id
     end

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -178,6 +178,9 @@ class PoltergeistAgent.Node
     window.getSelection().addRange(range)
     window.getSelection().deleteFromDocument()
 
+  getProperty: (name) ->
+    @element[name]
+
   getAttributes: ->
     attrs = {}
     for attr, i in @element.attributes

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -138,7 +138,7 @@ class Poltergeist.Browser
     @current_command.sendResponse this.node(page_id, id).deleteText()
 
   property: (page_id, id, name) ->
-    this.sendResponse this.node(page_id, id).getProperty(name)
+    @current_command.sendResponse this.node(page_id, id).getProperty(name)
 
   attribute: (page_id, id, name) ->
     @current_command.sendResponse this.node(page_id, id).getAttribute(name)

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -137,6 +137,9 @@ class Poltergeist.Browser
   delete_text: (page_id, id) ->
     @current_command.sendResponse this.node(page_id, id).deleteText()
 
+  property: (page_id, id, name) ->
+    this.sendResponse this.node(page_id, id).getProperty(name)
+
   attribute: (page_id, id, name) ->
     @current_command.sendResponse this.node(page_id, id).getAttribute(name)
 

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -275,6 +275,10 @@ PoltergeistAgent.Node = (function() {
     return window.getSelection().deleteFromDocument();
   };
 
+  Node.prototype.getProperty = function(name) {
+    return this.element[name];
+  };
+
   Node.prototype.getAttributes = function() {
     var attr, attrs, i, j, len, ref;
     attrs = {};

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -188,6 +188,10 @@ Poltergeist.Browser = (function() {
     return this.current_command.sendResponse(this.node(page_id, id).getAttributes());
   };
 
+  Browser.prototype.property = function(page_id, id, name) {
+    return this.sendResponse(this.node(page_id, id).getProperty(name));
+  };
+
   Browser.prototype.parents = function(page_id, id) {
     return this.current_command.sendResponse(this.node(page_id, id).parentIds());
   };

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -180,16 +180,16 @@ Poltergeist.Browser = (function() {
     return this.current_command.sendResponse(this.node(page_id, id).deleteText());
   };
 
+  Browser.prototype.property = function(page_id, id, name) {
+    return this.current_command.sendResponse(this.node(page_id, id).getProperty(name));
+  };
+
   Browser.prototype.attribute = function(page_id, id, name) {
     return this.current_command.sendResponse(this.node(page_id, id).getAttribute(name));
   };
 
   Browser.prototype.attributes = function(page_id, id, name) {
     return this.current_command.sendResponse(this.node(page_id, id).getAttributes());
-  };
-
-  Browser.prototype.property = function(page_id, id, name) {
-    return this.sendResponse(this.node(page_id, id).getProperty(name));
   };
 
   Browser.prototype.parents = function(page_id, id) {

--- a/lib/capybara/poltergeist/client/compiled/node.js
+++ b/lib/capybara/poltergeist/client/compiled/node.js
@@ -3,7 +3,7 @@ var slice = [].slice;
 Poltergeist.Node = (function() {
   var fn, i, len, name, ref;
 
-  Node.DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete', 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'getAttributes', 'isVisible', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest', 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText', 'containsSelection', 'path'];
+  Node.DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete', 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'getAttributes', 'isVisible', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest', 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText', 'containsSelection', 'path', 'getProperty'];
 
   function Node(page, id) {
     this.page = page;

--- a/lib/capybara/poltergeist/client/node.coffee
+++ b/lib/capybara/poltergeist/client/node.coffee
@@ -4,7 +4,8 @@ class Poltergeist.Node
   @DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete',
                 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'getAttributes',
                 'isVisible', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest',
-                'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText', 'containsSelection', 'path']
+                'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText', 'containsSelection',
+                'path', 'getProperty']
 
   constructor: (@page, @id) ->
 

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -55,7 +55,18 @@ module Capybara::Poltergeist
     end
 
     def [](name)
-      command :attribute, name
+      # Although the attribute matters, the property is consistent. Return that in
+      # preference to the attribute for links and images.
+      if (tag_name == 'img' and name == 'src') or (tag_name == 'a' and name == 'href' )
+         #if attribute exists get the property
+         value = command(:attribute, name) && command(:property, name)
+         return value
+      end
+
+      value = property(name)
+      value = command(:attribute, name) if value.nil? || value.is_a?(Hash)
+
+      value
     end
 
     def attributes

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -50,6 +50,10 @@ module Capybara::Poltergeist
       filter_text command(:visible_text)
     end
 
+    def property(name)
+      command :property, name
+    end
+
     def [](name)
       command :attribute, name
     end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -735,6 +735,20 @@ describe Capybara::Session do
       end
     end
 
+    context 'supports accessing element properties' do
+      before do
+        @session.visit '/poltergeist/property'
+      end
+
+      it 'gets property innerHTML' do
+        expect(@session.find(:css,'.some_class').native.property('innerHTML')).to eq '<p>foobar</p>'
+      end
+
+      it 'gets property outerHTML' do
+        expect(@session.find(:css,'.some_class').native.property('outerHTML')).to eq '<div class="some_class"><p>foobar</p></div>'
+      end
+    end
+
     it 'allows access to element attributes' do
       @session.visit '/poltergeist/attributes'
       expect(@session.find(:css,'#my_link').native.attributes).to eq(

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -257,6 +257,42 @@ describe Capybara::Session do
       end
     end
 
+    describe 'Node#checked?' do
+      before do
+        @session.visit '/poltergeist/attributes_properties'
+      end
+
+      it 'is a boolean' do
+        expect(@session.find_field('checked').checked?).to be true
+        expect(@session.find_field('unchecked').checked?).to be false
+      end
+    end
+
+    describe 'Node#[]' do
+      before do
+        @session.visit '/poltergeist/attributes_properties'
+      end
+
+      it 'gets normalized href' do
+        expect(@session.find(:link, 'Loop')['href']).to eq("http://#{@session.server.host}:#{@session.server.port}/poltergeist/attributes_properties")
+      end
+
+      it 'gets innerHTML' do
+        expect(@session.find(:css,'.some_other_class')['innerHTML']).to eq '<p>foobar</p>'
+      end
+
+      it 'gets attribute' do
+        link = @session.find(:link, 'Loop')
+        expect(link['data-random']).to eq '42'
+        expect(link['onclick']).to eq "return false;"
+      end
+
+      it 'gets boolean attributes as booleans' do
+        expect(@session.find_field('checked')['checked']).to be true
+        expect(@session.find_field('unchecked')['checked']).to be false
+      end
+    end
+
     it 'has no trouble clicking elements when the size of a document changes' do
       @session.visit('/poltergeist/long_page')
       @session.find(:css, '#penultimate').click
@@ -737,20 +773,20 @@ describe Capybara::Session do
 
     context 'supports accessing element properties' do
       before do
-        @session.visit '/poltergeist/property'
+        @session.visit '/poltergeist/attributes_properties'
       end
 
       it 'gets property innerHTML' do
-        expect(@session.find(:css,'.some_class').native.property('innerHTML')).to eq '<p>foobar</p>'
+        expect(@session.find(:css,'.some_other_class').native.property('innerHTML')).to eq '<p>foobar</p>'
       end
 
       it 'gets property outerHTML' do
-        expect(@session.find(:css,'.some_class').native.property('outerHTML')).to eq '<div class="some_class"><p>foobar</p></div>'
+        expect(@session.find(:css,'.some_other_class').native.property('outerHTML')).to eq '<div class="some_other_class"><p>foobar</p></div>'
       end
     end
 
     it 'allows access to element attributes' do
-      @session.visit '/poltergeist/attributes'
+      @session.visit '/poltergeist/attributes_properties'
       expect(@session.find(:css,'#my_link').native.attributes).to eq(
         'href' => '#', 'id' => 'my_link', 'class' => 'some_class', 'data' => 'rah!'
       )

--- a/spec/support/views/attributes.erb
+++ b/spec/support/views/attributes.erb
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <body>
-    <a href="#" id="my_link" class="some_class" data="rah!">Link me</a>
-  </body>
-</html>

--- a/spec/support/views/attributes_properties.erb
+++ b/spec/support/views/attributes_properties.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <a href="#" id="my_link" class="some_class" data="rah!">Link me</a>
+    <div class="some_other_class"><p>foobar</p></div>
+    <a href="/poltergeist/attributes_properties" onclick="return false;" data-random="42">Loop</a>
+    <input type="checkbox" id="checked" checked="checked"/>
+    <input type="checkbox" id="unchecked"/>
+  </body>
+</html>

--- a/spec/support/views/property.erb
+++ b/spec/support/views/property.erb
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <body>
-    <div class="some_class"><p>foobar</p></div>
-  </body>
-</html>

--- a/spec/support/views/property.erb
+++ b/spec/support/views/property.erb
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="some_class"><p>foobar</p></div>
+  </body>
+</html>


### PR DESCRIPTION
This changes Node#[] to be closer in behavior to when used with selenium in Capybara.  It prefers properties over attributes except in the case of the property being nil, or an object.