### PR TITLE
click on file input element after calling uploadFile in phantomjs 2

### DIFF
--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -162,8 +162,13 @@ class Poltergeist.Browser
     @currentPage.beforeUpload(node.id)
     @currentPage.uploadFile('[_poltergeist_selected]', value)
     @currentPage.afterUpload(node.id)
-
-    @current_command.sendResponse(true)
+    if phantom.version.major == 2
+      # In phantomjs 2 - uploadFile only fully works if executed within a user action
+      # It does however setup the filenames to be uploaded, so if we then click on the
+      # file input element the filenames will get set
+      @click(page_id, id)
+    else
+      @current_command.sendResponse(true)
 
   select: (page_id, id, value) ->
     @current_command.sendResponse this.node(page_id, id).select(value)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -207,7 +207,11 @@ Poltergeist.Browser = (function() {
     this.currentPage.beforeUpload(node.id);
     this.currentPage.uploadFile('[_poltergeist_selected]', value);
     this.currentPage.afterUpload(node.id);
-    return this.current_command.sendResponse(true);
+    if (phantom.version.major === 2) {
+      return this.click(page_id, id);
+    } else {
+      return this.current_command.sendResponse(true);
+    }
   };
 
   Browser.prototype.select = function(page_id, id, value) {


### PR DESCRIPTION
@route I took a look at the phantomjs and qtwebkit code and realized that while calling uploadFile doesn't actually set the filenames into the file input in Phantomjs 2 - it does set them into the temporary area they get copied from when the file input is triggered.   This means that all we need to do is click on the file input after calling uploadFile in Phantomjs2 and it works.   We may need to make the version check more granular when 2.0.1 is released depending on how it actually fixes the issue but file upload tests now work with phantomjs 2