### PR TITLE
Force scroll if needed for mouse events - Fix Issue #520

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 *   Fix domain setting of cookies when Capybara.app_host is set. (John Paul Ashenfelter, Thomas Walpole) [Issue #593]
 *   Fix click checking when svg element is overlapping (Thomas Walpole) [Issue #616]
 *   Fix null status code when some pages redirect (Thomas Walpole) [Issue #524]
+*   Fix cases where page isn't always scrolled when needed for a mouse click (Thomas Walpole) [Issue #520]
 
 ### 1.7.0 ###
 

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -195,6 +195,10 @@ class PoltergeistAgent.Node
 
   scrollIntoView: ->
     @element.scrollIntoViewIfNeeded()
+    #Sometimes scrollIntoViewIfNeeded doesn't seem to work, not really sure why.
+    #Just calling scrollIntoView doesnt work either, however calling scrollIntoView
+    #after scrollIntoViewIfNeeded when element is not in the viewport does appear to work
+    @element.scrollIntoView() unless this.isInViewport()
 
   value: ->
     if @element.tagName == 'SELECT' && @element.multiple
@@ -263,6 +267,14 @@ class PoltergeistAgent.Node
       element = element.parentElement
 
     return true
+
+  isInViewport: ->
+    rect = @element.getBoundingClientRect();
+
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= window.innerHeight &&
+    rect.right <= window.innerWidth
 
   isDisabled: ->
     @element.disabled || @element.tagName == 'OPTION' && @element.parentNode.disabled

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -299,7 +299,10 @@ PoltergeistAgent.Node = (function() {
   };
 
   Node.prototype.scrollIntoView = function() {
-    return this.element.scrollIntoViewIfNeeded();
+    this.element.scrollIntoViewIfNeeded();
+    if (!this.isInViewport()) {
+      return this.element.scrollIntoView();
+    }
   };
 
   Node.prototype.value = function() {
@@ -387,6 +390,12 @@ PoltergeistAgent.Node = (function() {
       element = element.parentElement;
     }
     return true;
+  };
+
+  Node.prototype.isInViewport = function() {
+    var rect;
+    rect = this.element.getBoundingClientRect();
+    return rect.top >= 0 && rect.left >= 0 && rect.bottom <= window.innerHeight && rect.right <= window.innerWidth;
   };
 
   Node.prototype.isDisabled = function() {

--- a/lib/capybara/poltergeist/client/compiled/node.js
+++ b/lib/capybara/poltergeist/client/compiled/node.js
@@ -3,7 +3,7 @@ var slice = [].slice;
 Poltergeist.Node = (function() {
   var fn, i, len, name, ref;
 
-  Node.DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete', 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'getAttributes', 'isVisible', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest', 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText', 'containsSelection', 'path', 'getProperty'];
+  Node.DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete', 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'getAttributes', 'isVisible', 'isInViewport', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest', 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText', 'containsSelection', 'path', 'getProperty'];
 
   function Node(page, id) {
     this.page = page;

--- a/lib/capybara/poltergeist/client/node.coffee
+++ b/lib/capybara/poltergeist/client/node.coffee
@@ -3,7 +3,7 @@
 class Poltergeist.Node
   @DELEGATES = ['allText', 'visibleText', 'getAttribute', 'value', 'set', 'setAttribute', 'isObsolete',
                 'removeAttribute', 'isMultiple', 'select', 'tagName', 'find', 'getAttributes',
-                'isVisible', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest',
+                'isVisible', 'isInViewport', 'position', 'trigger', 'parentId', 'parentIds', 'mouseEventTest',
                 'scrollIntoView', 'isDOMEqual', 'isDisabled', 'deleteText', 'containsSelection',
                 'path', 'getProperty']
 
@@ -32,7 +32,8 @@ class Poltergeist.Node
   mouseEvent: (name) ->
     this.scrollIntoView()
 
-    pos  = this.mouseEventPosition()
+    pos = this.mouseEventPosition()
+
     test = this.mouseEventTest(pos.x, pos.y)
 
     if test.status == 'success'
@@ -69,3 +70,4 @@ class Poltergeist.Node
 
   isEqual: (other) ->
     @page == other.page && this.isDOMEqual(other.id)
+

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -111,6 +111,11 @@ describe Capybara::Session do
         @session.click_link 'Link outside viewport'
         expect(@session.current_path).to eq('/')
       end
+
+      it 'scrolls into view if scrollIntoViewIfNeeded fails' do
+        @session.click_link 'Below the fold'
+        expect(@session.current_path).to eq('/')
+      end
     end
 
     describe 'Node#select' do
@@ -819,5 +824,6 @@ describe Capybara::Session do
         expect(@session).to have_xpath("//a[@id='open-twice' and @confirmed='false']")
       end
     end
+
   end
 end

--- a/spec/support/views/scroll.erb
+++ b/spec/support/views/scroll.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <title>scroll</title>
   </head>
@@ -13,5 +14,9 @@
         <a href="/">Link outside viewport</a>
       </p>
     </div>
+    <div style="height: 1000px"></div>
+    <a href="/">
+      <div>Below the fold</div>
+    </a>
   </body>
 </html>


### PR DESCRIPTION
Sometimes scrollIntoViewIfNeeded doesn't actually scroll the element into view - not really sure why though.  This change calls scrollIntoView if the element is still outside the viewport after scrollIntoViewIfNeeded was called.  As detailed in Issue #520 this seems to occur for elements with no dimension