### PR TITLE
Capture onResourceError in network traffic

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -250,7 +250,8 @@ module Capybara::Poltergeist
       command('network_traffic').values.map do |event|
         NetworkTraffic::Request.new(
           event['request'],
-          event['responseParts'].map { |response| NetworkTraffic::Response.new(response) }
+          event['responseParts'].map { |response| NetworkTraffic::Response.new(response) },
+          event['error'] ? NetworkTraffic::Error.new(event['error']) : nil
         )
       end
     end

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -4,7 +4,7 @@ var slice = [].slice,
 Poltergeist.WebPage = (function() {
   var command, delegate, fn1, fn2, i, j, len, len1, ref, ref1;
 
-  WebPage.CALLBACKS = ['onConsoleMessage', 'onLoadFinished', 'onInitialized', 'onLoadStarted', 'onResourceRequested', 'onResourceReceived', 'onError', 'onNavigationRequested', 'onUrlChanged', 'onPageCreated', 'onClosing'];
+  WebPage.CALLBACKS = ['onConsoleMessage', 'onError', 'onLoadFinished', 'onInitialized', 'onLoadStarted', 'onResourceRequested', 'onResourceReceived', 'onResourceError', 'onNavigationRequested', 'onUrlChanged', 'onPageCreated', 'onClosing'];
 
   WebPage.DELEGATES = ['open', 'sendEvent', 'uploadFile', 'release', 'render', 'renderBase64', 'goBack', 'goForward'];
 
@@ -127,7 +127,8 @@ Poltergeist.WebPage = (function() {
       }
       return this._networkTraffic[request.id] = {
         request: request,
-        responseParts: []
+        responseParts: [],
+        error: null
       };
     }
   };
@@ -145,6 +146,11 @@ Poltergeist.WebPage = (function() {
         return this._responseHeaders = response.headers;
       }
     }
+  };
+
+  WebPage.prototype.onResourceErrorNative = function(errorResponse) {
+    var ref2;
+    return (ref2 = this._networkTraffic[errorResponse.id]) != null ? ref2.error = errorResponse : void 0;
   };
 
   WebPage.prototype.injectAgent = function() {

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -1,7 +1,7 @@
 class Poltergeist.WebPage
-  @CALLBACKS = ['onConsoleMessage',
+  @CALLBACKS = ['onConsoleMessage','onError',
                 'onLoadFinished', 'onInitialized', 'onLoadStarted',
-                'onResourceRequested', 'onResourceReceived', 'onError',
+                'onResourceRequested', 'onResourceReceived', 'onResourceError',
                 'onNavigationRequested', 'onUrlChanged', 'onPageCreated',
                 'onClosing']
 
@@ -93,6 +93,7 @@ class Poltergeist.WebPage
       @_networkTraffic[request.id] = {
         request:       request,
         responseParts: []
+        error: null
       }
 
   onResourceReceivedNative: (response) ->
@@ -104,6 +105,9 @@ class Poltergeist.WebPage
       else
         @statusCode = response.status
         @_responseHeaders = response.headers
+
+  onResourceErrorNative: (errorResponse) ->
+    @_networkTraffic[errorResponse.id]?.error = errorResponse
 
   injectAgent: ->
     if this.native().evaluate(-> typeof __poltergeist) == "undefined"

--- a/lib/capybara/poltergeist/network_traffic.rb
+++ b/lib/capybara/poltergeist/network_traffic.rb
@@ -2,5 +2,6 @@ module Capybara::Poltergeist
   module NetworkTraffic
     require 'capybara/poltergeist/network_traffic/request'
     require 'capybara/poltergeist/network_traffic/response'
+    require 'capybara/poltergeist/network_traffic/error'
   end
 end

--- a/lib/capybara/poltergeist/network_traffic/error.rb
+++ b/lib/capybara/poltergeist/network_traffic/error.rb
@@ -1,0 +1,19 @@
+module Capybara::Poltergeist::NetworkTraffic
+  class Error
+    def initialize(data)
+      @data = data
+    end
+
+    def url
+      @data['url']
+    end
+
+    def code
+      @data['errorCode']
+    end
+
+    def description
+      @data['errorString']
+    end
+  end
+end

--- a/lib/capybara/poltergeist/network_traffic/request.rb
+++ b/lib/capybara/poltergeist/network_traffic/request.rb
@@ -1,10 +1,11 @@
 module Capybara::Poltergeist::NetworkTraffic
   class Request
-    attr_reader :response_parts
+    attr_reader :response_parts, :error
 
-    def initialize(data, response_parts = [])
+    def initialize(data, response_parts = [], error = nil)
       @data           = data
       @response_parts = response_parts
+      @error = error
     end
 
     def url

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -514,6 +514,14 @@ module Capybara::Poltergeist
         expect(request.response_parts.last.status).to eq(200)
       end
 
+      it 'captures errors' do
+        @session.visit('/poltergeist/with_ajax_fail')
+        expect(@session).to have_css('h1', text: 'Done')
+        error = @driver.network_traffic.last.error
+
+        expect(error).to be
+      end
+
       it 'keeps a running list between multiple web page views' do
         @session.visit('/poltergeist/with_js')
         expect(@driver.network_traffic.length).to eq(4)

--- a/spec/support/views/with_ajax_fail.erb
+++ b/spec/support/views/with_ajax_fail.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <title>poltergeist with_js</title>
+    <script src="/poltergeist/jquery.min.js" type="text/javascript" charset="utf-8"></script>
+  </head>
+  <body>
+    <h1>Here</h1>
+    <script>
+      $.ajax('/poltergeist/unexist.png', {
+        complete: function(){$('h1').text('Done');}
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This will capture ajax error information (like SSL handshake failures) and make it available in network traffic.