### PR TITLE
Rspec 3.4 displays the initial cause of exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ rvm:
   - 2.2.2
   - 2.1.6
   - 2.0.0
-  - 1.9.3
   - rbx-2
-  - jruby-19mode
 gemfile:
   - Gemfile
 env:
@@ -19,6 +17,10 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 matrix:
   include:
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.1_9_3
+    - rvm: jruby-19mode
+      gemfile: gemfiles/Gemfile.1_9_3
     - rvm: 2.2.2
       gemfile: Gemfile
       env: USE_PHANTOMJS2=true

--- a/gemfiles/Gemfile.1_9_3
+++ b/gemfiles/Gemfile.1_9_3
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+gemspec :path => '..'
+
+gem 'mime-types', '< 3.0'
+
+platforms :rbx do
+  gem 'rubysl'
+  gem 'racc'
+  gem 'json'
+end

--- a/lib/capybara/poltergeist/errors.rb
+++ b/lib/capybara/poltergeist/errors.rb
@@ -29,14 +29,15 @@ module Capybara
         response['name']
       end
 
-      def javascript_error
-        JSErrorItem.new(*response['args'])
+      def error_parameters
+        response['args'].join("\n")
       end
 
       def message
         "There was an error inside the PhantomJS portion of Poltergeist. " \
-          "This is probably a bug, so please report it. " \
-          "\n\n#{javascript_error}"
+          "If this is the error returned, and not the cause of a more detailed error response, " \
+          "this is probably a bug, so please report it. " \
+          "\n\n#{name}: #{error_parameters}"
       end
     end
 

--- a/poltergeist.gemspec
+++ b/poltergeist.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cliver',           '~> 0.3.1'
 
   s.add_development_dependency 'launchy',            '~> 2.0'
-  s.add_development_dependency 'rspec',              '~> 3.3.0'
+  s.add_development_dependency 'rspec',              '~> 3.4.0'
+  s.add_development_dependency 'rspec-core',         '!= 3.4.0' # 3.4.0 has an issue with rbx and ripper
   s.add_development_dependency 'sinatra',            '~> 1.0'
   s.add_development_dependency 'rake',               '~> 10.0'
   s.add_development_dependency 'image_size',         '~> 1.0'


### PR DESCRIPTION
RSpec 3.4 will now display the initial cause of exceptions raised which means BrowserError needs to be capable of handling more than two parameters passed in since it's the initial cause for MouseClickFailed errors.  This also updates version restrictions on the mime-types gem when testing with ruby 1.9 versions