### PR TITLE
Verify Client Rect is actually for the element - Fix Issue #281

### DIFF
--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -462,12 +462,26 @@ PoltergeistAgent.Node = (function() {
   };
 
   Node.prototype.position = function() {
-    var frameOffset, pos, rect;
-    rect = this.element.getClientRects()[0] || this.element.getBoundingClientRect();
+    var frameOffset, midpoint, pos, r, rect, rects, valid_rects;
+    frameOffset = this.frameOffset();
+    rects = this.element.getClientRects();
+    rect = __poltergeist.phantomjs_version.major === 1 ? (midpoint = function(r) {
+      return [(r.left + r.right) / 2 + frameOffset.left, (r.top + r.bottom) / 2 + frameOffset.top];
+    }, valid_rects = (function() {
+      var j, len, results1;
+      results1 = [];
+      for (j = 0, len = rects.length; j < len; j++) {
+        r = rects[j];
+        if (this.mouseEventTest.apply(this, midpoint(r)).status === 'success') {
+          results1.push(r);
+        }
+      }
+      return results1;
+    }).call(this), rect = valid_rects[0] || rects[0]) : rects[0];
+    rect || (rect = this.element.getBoundingClientRect());
     if (!rect) {
       throw new PoltergeistAgent.ObsoleteNode;
     }
-    frameOffset = this.frameOffset();
     pos = {
       top: rect.top + frameOffset.top,
       right: rect.right + frameOffset.left,

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -185,6 +185,9 @@ Poltergeist.WebPage = (function() {
       return typeof __poltergeist;
     }) === "undefined") {
       this["native"]().injectJs(phantom.libraryPath + "/agent.js");
+      this["native"]().evaluate(function(version) {
+        return __poltergeist.phantomjs_version = version;
+      }, phantom.version);
       ref2 = WebPage.EXTENSIONS;
       for (k = 0, len2 = ref2.length; k < len2; k++) {
         extension = ref2[k];

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -138,6 +138,9 @@ class Poltergeist.WebPage
   injectAgent: ->
     if this.native().evaluate(-> typeof __poltergeist) == "undefined"
       this.native().injectJs "#{phantom.libraryPath}/agent.js"
+      this.native().evaluate (version)->
+        __poltergeist.phantomjs_version = version
+      , phantom.version
       for extension in WebPage.EXTENSIONS
         this.native().injectJs extension
       return true

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -386,6 +386,19 @@ describe Capybara::Session do
         expect { @session.find(:css, '#myrect').click }.not_to raise_error
       end
 
+      it 'can click an element with a :before pseudo element' do
+        @session.click_on 'The Link'
+        expect(@session).to have_link('Clicked Link')
+      end
+
+      # This works with phantomjs 2 but phantomjs < 2 appears to not consider pseudo elements part of the
+      # element they are connected to
+      it 'can click an element that is only a :before pseudo element' do
+        skip "Phantomjs < 2 doesn't support this" unless phantom_version_is? '>= 2.0.0', @session.driver
+        @session.click_on 'pseudo_link'
+        expect(@session).to have_link('Pseudo clicked')
+      end
+
       context 'with #two overlapping #one' do
         before do
           @session.execute_script <<-JS

--- a/spec/support/views/click_test.erb
+++ b/spec/support/views/click_test.erb
@@ -24,6 +24,9 @@
     #four {
       background: green;
     }
+    #pseudo a:before {
+      content: "+";
+    }
   </style>
   <script type="text/javascript">
   window.onload = function() {
@@ -48,5 +51,10 @@
   <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
     <rect id="myrect" width="300" height="100" style="fill:rgb(0,0,255);stroke-width:1;stroke:rgb(0,0,0)" />
   </svg>
+  <div id="pseudo">
+    <a href="#" onclick="this.innerText='Clicked Link'">The Link</a>
+    <a href="#" id="pseudo_link" onclick="this.innerText='Pseudo clicked'"></a>
+  </div>
+
 </body>
 </html>


### PR DESCRIPTION
This attempts to fix an issue with clicking on elements that have a :before pseudo element when using PhantomJS < 2.  The problem occurs because the client rects returned by getClientRects correctly have the rect for the pseudo element, but that rect doesn't resolve to the element when we check it via mouse position (moveEventTest).  In PhantomJS 2 the rect does correctly resolve.  This fix checks for a rect that will resolve thereby allowing clicking on a portion of the element other than the pseudo element.  This has a drawback of not being able to click on elements whose total size is just a pseudo element, but it couldn't click on that before either.   Thoughts @route ?