### PR TITLE
make sure selected? returns a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Bug fixes ####
 *   Fix clicking on &lt;area> element in an image map (Thomas Walpole)
+*   Node#selected? now returns false rather than nil when an option element is not selected (Thomas Walpole)
 
 ### 1.8.1 ###
 

--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -120,7 +120,7 @@ module Capybara::Poltergeist
     end
 
     def selected?
-      self[:selected]
+      !!self[:selected]
     end
 
     def disabled?


### PR DESCRIPTION
Node#selected? is supposed to return a boolean - currently it returns nil if the node is not selected