### PR TITLE
add MRI 2.3.0 to the travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
    - tar -xvf $PWD/phantomjs-2.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs21 --strip-components 2 phantomjs-2.1.1-linux-x86_64/bin/phantomjs
    - chmod +x $PWD/travis-phantomjs21/phantomjs
 rvm:
+  - 2.3.0
   - 2.2.2
   - 2.1.6
   - 2.0.0


### PR DESCRIPTION
While working on #734, I noticed that the travis isn't running the build on MRI 2.3.0. I couldn't see any notes in the README about 2.3 not being supported, so I thought you may be interested in adding it to the build matrix. 