### PR TITLE
#749 Elements with no visible children should not return any text

### DIFF
--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -169,7 +169,10 @@ class PoltergeistAgent.Node
       if @element.nodeName == "TEXTAREA"
         @element.textContent
       else
-        @element.innerText || @element.textContent
+        if @element instanceof SVGElement
+          @element.textContent
+        else
+          @element.innerText
 
   deleteText: ->
     range = document.createRange()

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -262,7 +262,11 @@ PoltergeistAgent.Node = (function() {
       if (this.element.nodeName === "TEXTAREA") {
         return this.element.textContent;
       } else {
-        return this.element.innerText || this.element.textContent;
+        if (this.element instanceof SVGElement) {
+          return this.element.textContent;
+        } else {
+          return this.element.innerText;
+        }
       }
     }
   };

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -260,6 +260,10 @@ describe Capybara::Session do
       it 'considers opacity: 0 to not be visible' do
         expect(@session.find(:css, 'li', text: 'Transparent', visible: false).visible?).to be false
       end
+
+      it 'element with all children hidden returns empty text' do
+        expect(@session.find(:css, 'div').text).to eq('')
+      end
     end
 
     describe 'Node#checked?' do

--- a/spec/support/views/visible.erb
+++ b/spec/support/views/visible.erb
@@ -11,5 +11,9 @@
       <li style='visibility: hidden'>Hidden</li>
       <li style='opacity: 0.0'>Transparent</li>
     </ul>
+    <div>
+      <span style='display: none'>Display None</span>
+      <span style='visibility: hidden'>Hidden</span>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
visibleText should not return anything when all children are not visible.

Fix for issue #749 