### PR TITLE
Add clearMemoryCache command to the browser

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -344,6 +344,10 @@ module Capybara::Poltergeist
       command 'set_debug', !!val
     end
 
+    def clear_memory_cache
+      command 'clear_memory_cache'
+    end
+
     def command(name, *args)
       cmd = Command.new(name, *args)
       log cmd.message

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -507,3 +507,7 @@ class Poltergeist.Browser
 
   modal_message: ->
     @current_command.sendResponse(@processed_modal_messages.shift())
+
+  clear_memory_cache: ->
+    @currentPage.clearMemoryCache()
+    @current_command.sendResponse(true)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -692,6 +692,11 @@ Poltergeist.Browser = (function() {
     return this.current_command.sendResponse(this.processed_modal_messages.shift());
   };
 
+  Browser.prototype.clear_memory_cache = function() {
+    this.currentPage.clearMemoryCache();
+    return this.current_command.sendResponse(true);
+  };
+
   return Browser;
 
 })();

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -584,6 +584,10 @@ Poltergeist.WebPage = (function() {
     return parser.href;
   };
 
+  WebPage.prototype.clearMemoryCache = function() {
+    return this["native"]().clearMemoryCache();
+  };
+
   return WebPage;
 
 })();

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -409,3 +409,6 @@ class Poltergeist.WebPage
     parser = document.createElement('a')
     parser.href = url
     return parser.href
+  
+  clearMemoryCache: ->
+    this.native().clearMemoryCache()


### PR DESCRIPTION
I'm getting the same test failures as @thom-nic in  https://github.com/teampoltergeist/poltergeist/issues/719

I added `clearMemoryCache` to the Browser wrapper to be able to call it after each test.

```
page.driver.browser.clear_memory_cache
```

It resolved the issue and I didn't encounter any crashes (yet?).

--

Regarding the tests – should I add them for `Browser`, or is it better to add `clear_memory_cache` to `Driver` and have it tested thought it?