### PR TITLE
WIP: Allow to pass format and quality to save_screenshot.

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -217,8 +217,9 @@ module Capybara::Poltergeist
     end
 
     def render(path, options = {})
+      format, quality = options.values_at(:format, :quality)
       check_render_options!(options)
-      command 'render', path.to_s, !!options[:full], options[:selector]
+      command 'render', path.to_s, !!options[:full], options[:selector], format, quality
     end
 
     def render_base64(format, options = {})

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -359,10 +359,13 @@ class Poltergeist.Browser
     encoded_image = @currentPage.renderBase64(format)
     @current_command.sendResponse(encoded_image)
 
-  render: (path, full, selector = null) ->
+  render: (path, full, selector = null, format = null, quality = null) ->
     dimensions = this.set_clip_rect(full, selector)
+    options = {}
+    options["format"] = format if format
+    options["quality"] = quality if quality
     @currentPage.setScrollPosition(left: 0, top: 0)
-    @currentPage.render(path)
+    @currentPage.render(path, options)
     @currentPage.setScrollPosition(left: dimensions.left, top: dimensions.top)
     @current_command.sendResponse(true)
 

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -485,17 +485,30 @@ Poltergeist.Browser = (function() {
     return this.current_command.sendResponse(encoded_image);
   };
 
-  Browser.prototype.render = function(path, full, selector) {
-    var dimensions;
+  Browser.prototype.render = function(path, full, selector, format, quality) {
+    var dimensions, options;
     if (selector == null) {
       selector = null;
     }
+    if (format == null) {
+      format = null;
+    }
+    if (quality == null) {
+      quality = null;
+    }
     dimensions = this.set_clip_rect(full, selector);
+    options = {};
+    if (format) {
+      options["format"] = format;
+    }
+    if (quality) {
+      options["quality"] = quality;
+    }
     this.currentPage.setScrollPosition({
       left: 0,
       top: 0
     });
-    this.currentPage.render(path);
+    this.currentPage.render(path, options);
     this.currentPage.setScrollPosition({
       left: dimensions.left,
       top: dimensions.top

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -197,6 +197,21 @@ module Capybara::Poltergeist
         expect(File.exist?(file)).to be true
       end
 
+      it 'supports rendering the page to file without extension when format is specified' do
+        FileUtils.rm_f file
+        begin
+          file = POLTERGEIST_ROOT + "/spec/tmp/screenshot"
+          FileUtils.rm_f file
+          @session.visit('/')
+
+          @driver.save_screenshot(file, format: 'jpg')
+
+          expect(File.exist?(file)).to be true
+        ensure
+          FileUtils.rm_f file
+        end
+      end
+
       shared_examples 'when #zoom_factor= is set' do
         let(:format) { :xbm }
 


### PR DESCRIPTION
# Info

follow up of #758 

With this change you can pass format and quality to save_screenshot as you can do in phantomjs. It is useful if you can't control file extension, because phantomjs will not save render for file without specified format (via file extension or explicitly via option passed to render function).

I found out there's also unsupported `quality` option for phantomjs render function. I would like to add support for that option also.

This just an dirty implementation idea. Feel free to ping me if that make sense and I'll finish this PR.
# Before

``` ruby
@driver.save_screenshot('file_without_extension") #=> will not save file
```
# After

``` ruby
@driver.save_screenshot("file_without_extension", format: 'png') #=> will save file
```
# TODO
- [ ] refactor browser.coffee
- [ ] refactor related specs
- [ ] test quality option
