### PR TITLE
Support 'SameSite' cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features ####
 *   Added ability to set proxy at runtime (Dmitry Vorotilin)
+*   Implement basic support for `SameSite` cookies (Reed Loden)
 
 ### 1.9.0 ###
 

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ The following methods are used to inspect and manipulate cookies:
 * `page.driver.cookies` - a hash of cookies accessible to the current
   page. The keys are cookie names. The values are `Cookie` objects, with
   the following methods: `name`, `value`, `domain`, `path`, `secure?`,
-  `httponly?`, `expires`.
+  `httponly?`, `samesite`, `expires`.
 * `page.driver.set_cookie(name, value, options = {})` - set a cookie.
   The options hash can take the following keys: `:domain`, `:path`,
-  `:secure`, `:httponly`, `:expires`. `:expires` should be a `Time`
-  object.
+  `:secure`, `:httponly`, `:samesite`, `:expires`. `:expires` should be a
+  `Time` object.
 * `page.driver.remove_cookie(name)` - remove a cookie
 * `page.driver.clear_cookies` - clear all cookies
 

--- a/lib/capybara/poltergeist/cookie.rb
+++ b/lib/capybara/poltergeist/cookie.rb
@@ -28,6 +28,10 @@ module Capybara::Poltergeist
       @attributes['httponly']
     end
 
+    def samesite
+      @attributes['samesite']
+    end
+
     def expires
       Time.at @attributes['expiry'] if @attributes['expiry']
     end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -605,6 +605,7 @@ module Capybara::Poltergeist
         expect(cookie.path).to eq('/')
         expect(cookie.secure?).to be false
         expect(cookie.httponly?).to be false
+        expect(cookie.samesite).to be_nil
         expect(cookie.expires).to be_nil
       end
 


### PR DESCRIPTION
Add support for same-site cookies, which helps protect against
CSRF and other leakage attacks by ensuring that cookies are not
sent to any third-party sites.

https://tools.ietf.org/html/draft-west-first-party-cookies-07
https://www.chromestatus.com/feature/4672634709082112