### PR TITLE
Build dependency fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem "listen", "3.0.6"
+
 platforms :rbx do
   gem 'rubysl'
   gem 'racc'

--- a/gemfiles/Gemfile.1_9_3
+++ b/gemfiles/Gemfile.1_9_3
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'mime-types', '< 3.0'
+gem "listen", "3.0.6"
 
 platforms :rbx do
   gem 'rubysl'

--- a/gemfiles/Gemfile.capybara_master
+++ b/gemfiles/Gemfile.capybara_master
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'capybara', github: 'jnicklas/capybara'
+gem "listen", "3.0.6"
 
 platforms :rbx do
   gem 'rubysl'


### PR DESCRIPTION
This PR is attempt to resolve problem recently introduced by Guard's `listen` gem dependency change which from 3.1.0 requires Ruby 2.2.3+, more here https://github.com/guard/listen/issues/374 . Of course this fails most of `poltergeist` tests platforms except Ruby 2.3.0.
The only part which I couldn't get throughout is `rbx-2` platform which fails miserably with lot of tests. If somebody could look into Travis. Maybe we should radically EOL old rubies and switch to latest rbx-3.36?