### PR TITLE
bug: args to normalize_keys should not be mutated

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -418,8 +418,8 @@ module Capybara::Poltergeist
           # [:Shift, "s"] => { modifier: "shift", key: "S" }
           # [:Ctrl, :Left] => { modifier: "ctrl", key: :Left }
           # [:Ctrl, :Shift, :Left] => { modifier: "ctrl,shift", key: :Left }
-          letter = key.pop
-          symbol = key.map { |k| k.to_s.downcase }.join(',')
+          letter = key.first
+          symbol = key.drop(1).map { |k| k.to_s.downcase }.join(',')
 
           { modifier: symbol.to_s.downcase, key: letter.capitalize }
         when Symbol

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -418,8 +418,8 @@ module Capybara::Poltergeist
           # [:Shift, "s"] => { modifier: "shift", key: "S" }
           # [:Ctrl, :Left] => { modifier: "ctrl", key: :Left }
           # [:Ctrl, :Shift, :Left] => { modifier: "ctrl,shift", key: :Left }
-          letter = key.first
-          symbol = key.drop(1).map { |k| k.to_s.downcase }.join(',')
+          letter = key.last
+          symbol = key[0...-1].map { |k| k.to_s.downcase }.join(',')
 
           { modifier: symbol.to_s.downcase, key: letter.capitalize }
         when Symbol


### PR DESCRIPTION
Capybara's synchronize will retry with the same arguments. So we don't want to mutate the arguments.