### PR TITLE
Fix typo `noSuchWindowError` -> `NoSuchWindowError`

### DIFF
--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -164,7 +164,7 @@ module Capybara::Poltergeist
       return locator if window_handles.include? locator
 
       handle = command 'window_handle', locator
-      raise noSuchWindowError unless handle
+      raise NoSuchWindowError unless handle
       return handle
     end
 


### PR DESCRIPTION
Fix typo.
It causes a `NameError`.