### PR TITLE
Inherit settings when opening new window

### DIFF
--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -52,6 +52,9 @@ class Poltergeist.Browser
     @page.onPageCreated = (newPage) =>
       page = new Poltergeist.WebPage(newPage)
       page.handle = "#{@_counter++}"
+      page.urlBlacklist = @page.urlBlacklist
+      page.urlWhitelist = @page.urlWhitelist
+      page.setViewportSize(width: @width, height: @height)
       @pages.push(page)
 
     return

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -68,6 +68,12 @@ Poltergeist.Browser = (function() {
         var page;
         page = new Poltergeist.WebPage(newPage);
         page.handle = "" + (_this._counter++);
+        page.urlBlacklist = _this.page.urlBlacklist;
+        page.urlWhitelist = _this.page.urlWhitelist;
+        page.setViewportSize({
+          width: _this.width,
+          height: _this.height
+        });
         return _this.pages.push(page);
       };
     })(this);

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -809,6 +809,22 @@ module Capybara::Poltergeist
       expect(@driver.window_handles).to eq(['0', '1'])
     end
 
+    it 'inherits settings in new windows' do
+      @session.visit '/'
+
+      new_tab = @session.window_opened_by do
+        @session.execute_script <<-JS
+          window.open('/poltergeist/simple')
+        JS
+      end
+
+      @session.within_window(new_tab) do
+        expect(
+          @driver.evaluate_script('[window.innerWidth, window.innerHeight]')
+        ).to eq([1024, 768])
+      end
+    end
+
     it 'resizes windows' do
       @session.visit '/'
 


### PR DESCRIPTION
Inherit both window size and url blacklist/whitelist when opening new window

- Window size because it's closer to what the browser does when opening a new tab.
  By default, when opening a new window, you get a 400x300 window
- Url blacklist/whitelist because it's expected to be global