### PR TITLE
Driver url filter config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 *   Fix within_frame when called on a frame whose src attribute is about:blank (Thomas Walpole) [Issue #772]
 *   Elements with no visible children should not return text (Peter Oxenham) [Issue #749]
 *   Fix error type returned by #within_window when window not found (oieioi)
+*   New windows inherit the size of the window they were opened from (StefanH, Thomas Walpole) [Issue #597]
+*   New windows inherit the blacklist/whitelist setting of the window they were opened from as expected (StefanH, Thomas Walpole)
 
 ### 1.9.0 ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 *   Implement basic support for accessing `SameSite` attribute of cookies (Reed Loden)
 *   Add clear_memory_cache to the driver (Piotr Gaertig)
 *   Allowing passing format and quality options to save_screenshot (Josef Šimánek, Thomas Walpole)
+*   Allow configuring default url_blacklist and url_whitelist in the driver configuration (Thomas Walpole)
 
 #### Bug fixes ####
 *   Fix within_frame when called on a frame whose src attribute is about:blank (Thomas Walpole) [Issue #772]

--- a/README.md
+++ b/README.md
@@ -272,9 +272,10 @@ end
     the phantomjs browser. Useful for faking unsupported APIs.
 *   `:port` (Fixnum) - The port which should be used to communicate
     with the PhantomJS process. Defaults to a random open port.
+*   `:url_blacklist` (Array) - Default session url blacklist - expressed as an array of strings to match against requested URLs.
+*   `:url_whitelist` (Array) - Default session url whitelist - expressed as an array of strings to match against requested URLs.
 
 ### URL Blacklisting & Whitelisting ###
-
 Poltergeist supports URL blacklisting, which allows you
 to prevent scripts from running on designated domains:
 
@@ -294,8 +295,6 @@ URL whitelist of domains that are essential or a blacklist of
 domains that are not essential, such as ad networks or analytics,
 to your testing environment.
 
-Make sure you set it before each running test, because this setting's cleaned
-up when capybara does reset.
 
 ## Troubleshooting ##
 

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -52,6 +52,9 @@ class Poltergeist.Browser
     @page.onPageCreated = (newPage) =>
       page = new Poltergeist.WebPage(newPage)
       page.handle = "#{@_counter++}"
+      page.urlBlacklist = @page.urlBlacklist
+      page.urlWhitelist = @page.urlWhitelist
+      page.setViewportSize(@page.viewportSize())
       @pages.push(page)
 
     return

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -68,6 +68,9 @@ Poltergeist.Browser = (function() {
         var page;
         page = new Poltergeist.WebPage(newPage);
         page.handle = "" + (_this._counter++);
+        page.urlBlacklist = _this.page.urlBlacklist;
+        page.urlWhitelist = _this.page.urlWhitelist;
+        page.setViewportSize(_this.page.viewportSize());
         return _this.pages.push(page);
       };
     })(this);

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -409,10 +409,10 @@ class Poltergeist.WebPage
     parser = document.createElement('a')
     parser.href = url
     return parser.href
-  
+
   clearMemoryCache: ->
-    clearMemoryCache = this.native().clearMemoryCache 
+    clearMemoryCache = this.native().clearMemoryCache
     if typeof clearMemoryCache == "function"
       clearMemoryCache()
-    else 
+    else
       throw new Poltergeist.UnsupportedFeature("clearMemoryCache is supported since PhantomJS 2.0.0")

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -26,6 +26,8 @@ module Capybara::Poltergeist
         browser.js_errors  = options[:js_errors] if options.key?(:js_errors)
         browser.extensions = options.fetch(:extensions, [])
         browser.debug      = true if options[:debug]
+        browser.url_blacklist = options[:url_blacklist] if options.key?(:url_blacklist)
+        browser.url_whitelist = options[:url_whitelist] if options.key?(:url_whitelist)
         browser
       end
     end
@@ -175,6 +177,8 @@ module Capybara::Poltergeist
 
     def reset!
       browser.reset
+      browser.url_blacklist = options[:url_blacklist] if options.key?(:url_blacklist)
+      browser.url_whitelist = options[:url_whitelist] if options.key?(:url_whitelist)
       @started = false
     end
 

--- a/spec/support/views/url_whitelist.erb
+++ b/spec/support/views/url_whitelist.erb
@@ -3,6 +3,7 @@
   <body>
     We are loading some wanted action here.
     <iframe src="/poltergeist/wanted" name="framename"></iframe>
+    <iframe src="/poltergeist/unwanted" name="unwantedframe"></iframe>
     <img src="/poltergeist/wanted" style="height:100px;width:100px;" />
     <script src="/poltergeist/wanted" />
   </body>


### PR DESCRIPTION
This allows to configure the default black/whitelist in the driver config, and I think along with the change in PR #783 will make the black/whitelists more usable, predictable, and easier to configure.  @route - thoughts?