### PR TITLE
Default to key string if no keyCode provided by PhantomJS

### DIFF
--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -346,7 +346,10 @@ class Poltergeist.Browser
       target.mouseEvent('click')
 
     for sequence in keys
-      key = if sequence.key? then @currentPage.keyCode(sequence.key) else sequence
+      key = if sequence.key?
+        @currentPage.keyCode(sequence.key) || sequence.key
+      else
+        sequence
       if sequence.modifier?
         modifier_keys = @currentPage.keyModifierKeys(sequence.modifier)
         modifier_code = @currentPage.keyModifierCode(sequence.modifier)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -457,7 +457,7 @@ Poltergeist.Browser = (function() {
     }
     for (i = 0, len = keys.length; i < len; i++) {
       sequence = keys[i];
-      key = sequence.key != null ? this.currentPage.keyCode(sequence.key) : sequence;
+      key = sequence.key != null ? this.currentPage.keyCode(sequence.key) || sequence.key : sequence;
       if (sequence.modifier != null) {
         modifier_keys = this.currentPage.keyModifierKeys(sequence.modifier);
         modifier_code = this.currentPage.keyModifierCode(sequence.modifier);

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -422,24 +422,23 @@ Poltergeist.WebPage = (function() {
     var frame_no;
     if (this["native"]().switchToFrame(name)) {
       return true;
-    } else {
-      frame_no = this["native"]().evaluate(function(frame_name) {
-        var f, frames, idx;
-        frames = document.querySelectorAll("iframe, frame");
-        return ((function() {
-          var k, len2, results;
-          results = [];
-          for (idx = k = 0, len2 = frames.length; k < len2; idx = ++k) {
-            f = frames[idx];
-            if ((f != null ? f['name'] : void 0) === frame_name || (f != null ? f['id'] : void 0) === frame_name) {
-              results.push(idx);
-            }
-          }
-          return results;
-        })())[0];
-      }, name);
-      return (frame_no != null) && this["native"]().switchToFrame(frame_no);
     }
+    frame_no = this["native"]().evaluate(function(frame_name) {
+      var f, frames, idx;
+      frames = document.querySelectorAll("iframe, frame");
+      return ((function() {
+        var k, len2, results;
+        results = [];
+        for (idx = k = 0, len2 = frames.length; k < len2; idx = ++k) {
+          f = frames[idx];
+          if ((f != null ? f['name'] : void 0) === frame_name || (f != null ? f['id'] : void 0) === frame_name) {
+            results.push(idx);
+          }
+        }
+        return results;
+      })())[0];
+    }, name);
+    return (frame_no != null) && this["native"]().switchToFrame(frame_no);
   };
 
   WebPage.prototype.popFrame = function(pop_all) {

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -1212,6 +1212,14 @@ module Capybara::Poltergeist
 
         expect(input.value).to eq('S')
       end
+
+      it 'generates correct events with keyCodes for modified puncation' do
+        input = @session.find(:css, '#empty_input')
+
+        input.send_keys([:shift, '.'], [:shift, 't'])
+
+        expect(@session.find(:css, '#key-events-output')).to have_text("keydown:16 keydown:190 keydown:16 keydown:84")
+      end
     end
 
     context 'set' do

--- a/spec/support/views/send_keys.erb
+++ b/spec/support/views/send_keys.erb
@@ -14,7 +14,7 @@
     <form id="without_submit_button">
       <input type="text">
     </form>
-
+    <div id="key-events-output"></div>
     <script>
       function processForm(e) {
           if (e.preventDefault) e.preventDefault();
@@ -24,6 +24,12 @@
 
       var form = document.getElementById("without_submit_button");
       form.addEventListener("submit", processForm);
+
+      var input = document.getElementById("empty_input");
+      input.addEventListener("keydown", function(e){
+        var log = document.getElementById("key-events-output");
+        log.textContent = log.textContent + "keydown:"+e.keyCode+" ";
+      })
     </script>
   </body>
 </html>


### PR DESCRIPTION
This fixes Issue#807 by just passing the key string if PhantomJS doesn't have a mapping for the keyCode.