### PR TITLE
Support partial string and regular expression matches for modal dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Bug fixes ####
 *   Check isContentEditable property instead of contenteditable attribute so contenteditable children can be modified
 *   In send_keys default to key string if no keyCode provided by PhantomJS when using modifier (Thomas Walpole)[Issue #807]
+*   Add support for partial string and regular expression matches for modal dialogs (Sean Fisk) [Issue #815]
 
 ### 1.10.0 ###
 

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -396,13 +396,13 @@ module Capybara::Poltergeist
       start_time    = Time.now
       timeout_sec   = options[:wait] || begin Capybara.default_max_wait_time rescue Capybara.default_wait_time end
       expect_text   = options[:text]
+      expect_regexp = expect_text.is_a?(Regexp) ? expect_text : Regexp.escape(expect_text.to_s)
       not_found_msg = 'Unable to find modal dialog'
       not_found_msg += " with #{expect_text}" if expect_text
 
       begin
         modal_text = browser.modal_message
-        raise Capybara::ModalNotFound if modal_text.nil?
-        raise Capybara::ModalNotFound if (expect_text && (modal_text != expect_text))
+        raise Capybara::ModalNotFound if modal_text.nil? || (expect_text && !modal_text.match(expect_regexp))
       rescue Capybara::ModalNotFound => e
         raise e, not_found_msg if (Time.now - start_time) >= timeout_sec
         sleep(0.05)

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 skip = []
@@ -903,6 +904,24 @@ describe Capybara::Session do
     context 'modals' do
       before do
         @session.visit '/poltergeist/with_js'
+      end
+
+      it 'matches on partial strings' do
+        expect {
+          @session.accept_confirm '[reg.exp] (chara©+er$)' do
+            @session.click_link('Open for match')
+          end
+        }.not_to raise_error
+        expect(@session).to have_xpath("//a[@id='open-match' and @confirmed='true']")
+      end
+
+      it 'matches on regular expressions' do
+        expect {
+          @session.accept_confirm(/^.t.ext.*\[\w{3}\.\w{3}\]/i) do
+            @session.click_link('Open for match')
+          end
+        }.not_to raise_error
+        expect(@session).to have_xpath("//a[@id='open-match' and @confirmed='true']")
       end
 
       it 'works with nested modals' do

--- a/spec/support/public/test.js
+++ b/spec/support/public/test.js
@@ -46,6 +46,13 @@ $(function() {
       $('#changes_on_blur').text($(this).val())
     })
 
+  $('#open-match')
+    .click(function() {
+      if (confirm('{T}ext \\w|th [reg.exp] (chara©+er$)?')) {
+        $(this).attr('confirmed', 'true');
+      }
+    })
+
   $('#open-twice')
     .click(function() {
       if (confirm('Are you sure?')) {

--- a/spec/support/views/with_js.erb
+++ b/spec/support/views/with_js.erb
@@ -65,6 +65,10 @@
     </select>
 
     <p>
+      <a href="#" id="open-match">Open for match</a>
+    </p>
+
+    <p>
       <a href="#" id="open-twice">Open check twice</a>
     </p>
   </body>


### PR DESCRIPTION
Capybara's [`accept_modal`](http://www.rubydoc.info/gems/capybara/2.9.2/Capybara/Driver/Base#accept_modal-instance_method) function as well as the rest of the modal dialog API state that the `text` option may be a `String` or `Regexp` that *is in the message shown in the modal*. Currently, Poltergeist supports only exact matches and does not support receiving a `Regexp` for matching.

This pull request adds support for partial string matches as well as matching via regular expression. The code is based on the [Selenium implementation of `find_modal`](https://github.com/jnicklas/capybara/blob/master/lib/capybara/selenium/driver.rb#L286).

I also added a couple tests to verify this behavior. I wasn't sure if they should go in this repo or in Capybara itself, since those tests could be potentially useful to all drivers. If you'd like them moved to Capybara, just let me know!

Thank you for creating and maintaining Poltergeist!