### PR TITLE
remove JSON requirement from agent

### DIFF
--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -1,10 +1,5 @@
 # This is injected into each page that is loaded
-
 class PoltergeistAgent
-  # Since this code executes in the sites browser space - copy needed JSON functions
-  # in case user code messes with JSON (early mootools for instance)
-  @.JSON ||= { parse: JSON.parse, stringify: JSON.stringify }
-
   constructor: ->
     @elements = []
     @nodes    = {}
@@ -14,19 +9,6 @@ class PoltergeistAgent
       { value: this[name].apply(this, args) }
     catch error
       { error: { message: error.toString(), stack: error.stack } }
-
-  @stringify: (object) ->
-    try
-      PoltergeistAgent.JSON.stringify object, (key, value) ->
-        if Array.isArray(this[key])
-          return this[key]
-        else
-          return value
-    catch error
-      if error instanceof TypeError
-        '"(cyclic structure)"'
-      else
-        throw error
 
   # Somehow PhantomJS returns all characters(brackets, etc) properly encoded
   # except whitespace character in pathname part of the location. This hack
@@ -194,7 +176,7 @@ class PoltergeistAgent.Node
     if name == 'checked' || name == 'selected'
       @element[name]
     else
-      @element.getAttribute(name)
+      @element.getAttribute(name) ? undefined
 
   scrollIntoView: ->
     @element.scrollIntoViewIfNeeded()

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -1,11 +1,6 @@
 var PoltergeistAgent;
 
 PoltergeistAgent = (function() {
-  PoltergeistAgent.JSON || (PoltergeistAgent.JSON = {
-    parse: JSON.parse,
-    stringify: JSON.stringify
-  });
-
   function PoltergeistAgent() {
     this.elements = [];
     this.nodes = {};
@@ -25,26 +20,6 @@ PoltergeistAgent = (function() {
           stack: error.stack
         }
       };
-    }
-  };
-
-  PoltergeistAgent.stringify = function(object) {
-    var error, error1;
-    try {
-      return PoltergeistAgent.JSON.stringify(object, function(key, value) {
-        if (Array.isArray(this[key])) {
-          return this[key];
-        } else {
-          return value;
-        }
-      });
-    } catch (error1) {
-      error = error1;
-      if (error instanceof TypeError) {
-        return '"(cyclic structure)"';
-      } else {
-        throw error;
-      }
     }
   };
 
@@ -296,10 +271,11 @@ PoltergeistAgent.Node = (function() {
   };
 
   Node.prototype.getAttribute = function(name) {
+    var ref;
     if (name === 'checked' || name === 'selected') {
       return this.element[name];
     } else {
-      return this.element.getAttribute(name);
+      return (ref = this.element.getAttribute(name)) != null ? ref : void 0;
     }
   };
 

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -498,32 +498,20 @@ Poltergeist.WebPage = (function() {
   };
 
   WebPage.prototype.evaluate = function() {
-    var args, fn;
+    var args, fn, ref2;
     fn = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
     this.injectAgent();
-    return JSON.parse(this.sanitize(this["native"]().evaluate("function() { return PoltergeistAgent.stringify(" + (this.stringifyCall(fn, args)) + ") }")));
-  };
-
-  WebPage.prototype.sanitize = function(potential_string) {
-    if (typeof potential_string === "string") {
-      return potential_string.replace("\n", "\\n").replace("\r", "\\r");
-    } else {
-      return potential_string;
-    }
+    return (ref2 = this["native"]()).evaluate.apply(ref2, ["function() { result = " + (this.stringifyCall(fn)) + "; return (result == null) ? undefined : result; }"].concat(slice.call(args)));
   };
 
   WebPage.prototype.execute = function() {
-    var args, fn;
+    var args, fn, ref2;
     fn = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
-    return this["native"]().evaluate("function() { " + (this.stringifyCall(fn, args)) + " }");
+    return (ref2 = this["native"]()).evaluate.apply(ref2, ["function() { " + (this.stringifyCall(fn)) + " }"].concat(slice.call(args)));
   };
 
-  WebPage.prototype.stringifyCall = function(fn, args) {
-    if (args.length === 0) {
-      return "(" + (fn.toString()) + ")()";
-    } else {
-      return "(" + (fn.toString()) + ").apply(this, PoltergeistAgent.JSON.parse(" + (JSON.stringify(JSON.stringify(args))) + "))";
-    }
+  WebPage.prototype.stringifyCall = function(fn) {
+    return "(" + (fn.toString()) + ").apply(this, arguments)";
   };
 
   WebPage.prototype.bindCallback = function(name) {

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -33,6 +33,9 @@ Poltergeist.WebPage = (function() {
       callback = ref[i];
       this.bindCallback(callback);
     }
+    if (phantom.version.major < 2) {
+      this._overrideNativeEvaluate();
+    }
   }
 
   ref = WebPage.COMMANDS;
@@ -576,6 +579,92 @@ Poltergeist.WebPage = (function() {
     } else {
       throw new Poltergeist.UnsupportedFeature("clearMemoryCache is supported since PhantomJS 2.0.0");
     }
+  };
+
+  WebPage.prototype._overrideNativeEvaluate = function() {
+    return this._native.evaluate = function (func, args) {
+        function quoteString(str) {
+            var c, i, l = str.length, o = '"';
+            for (i = 0; i < l; i += 1) {
+                c = str.charAt(i);
+                if (c >= ' ') {
+                    if (c === '\\' || c === '"') {
+                        o += '\\';
+                    }
+                    o += c;
+                } else {
+                    switch (c) {
+                    case '\b':
+                        o += '\\b';
+                        break;
+                    case '\f':
+                        o += '\\f';
+                        break;
+                    case '\n':
+                        o += '\\n';
+                        break;
+                    case '\r':
+                        o += '\\r';
+                        break;
+                    case '\t':
+                        o += '\\t';
+                        break;
+                    default:
+                        c = c.charCodeAt();
+                        o += '\\u00' + Math.floor(c / 16).toString(16) +
+                            (c % 16).toString(16);
+                    }
+                }
+            }
+            return o + '"';
+        }
+
+        function detectType(value) {
+            var s = typeof value;
+            if (s === 'object') {
+                if (value) {
+                    if (value instanceof Array) {
+                        s = 'array';
+                    } else if (value instanceof RegExp) {
+                        s = 'regexp';
+                    } else if (value instanceof Date) {
+                        s = 'date';
+                    }
+                } else {
+                    s = 'null';
+                }
+            }
+            return s;
+        }
+
+        var str, arg, argType, i, l;
+        if (!(func instanceof Function || typeof func === 'string' || func instanceof String)) {
+            throw "Wrong use of WebPage#evaluate";
+        }
+        str = 'function() { return (' + func.toString() + ')(';
+        for (i = 1, l = arguments.length; i < l; i++) {
+            arg = arguments[i];
+            argType = detectType(arg);
+
+            switch (argType) {
+            case "object":      //< for type "object"
+            case "array":       //< for type "array"
+                str += JSON.stringify(arg) + ","
+                break;
+            case "date":        //< for type "date"
+                str += "new Date(" + JSON.stringify(arg) + "),"
+                break;
+            case "string":      //< for type "string"
+                str += quoteString(arg) + ',';
+                break;
+            default:            // for types: "null", "number", "function", "regexp", "undefined"
+                str += arg + ',';
+                break;
+            }
+        }
+        str = str.replace(/,$/, '') + '); }';
+        return this.evaluateJavaScript(str);
+    };;
   };
 
   return WebPage;

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -341,25 +341,14 @@ class Poltergeist.WebPage
 
   evaluate: (fn, args...) ->
     this.injectAgent()
-    JSON.parse this.sanitize(this.native().evaluate("function() { return PoltergeistAgent.stringify(#{this.stringifyCall(fn, args)}) }"))
-
-  sanitize: (potential_string) ->
-    if typeof(potential_string) == "string"
-      # JSON doesn't like \r or \n in strings unless escaped
-      potential_string.replace("\n","\\n").replace("\r","\\r")
-    else
-      potential_string
+    this.native().evaluate("function() { result = #{this.stringifyCall(fn)};
+      return (result == null) ? undefined : result; }", args...)
 
   execute: (fn, args...) ->
-    this.native().evaluate("function() { #{this.stringifyCall(fn, args)} }")
+    this.native().evaluate("function() { #{this.stringifyCall(fn)} }", args...)
 
-  stringifyCall: (fn, args) ->
-    if args.length == 0
-      "(#{fn.toString()})()"
-    else
-      # The JSON.stringify happens twice because the second time we are essentially
-      # escaping the string.
-      "(#{fn.toString()}).apply(this, PoltergeistAgent.JSON.parse(#{JSON.stringify(JSON.stringify(args))}))"
+  stringifyCall: (fn) ->
+    "(#{fn.toString()}).apply(this, arguments)"
 
   bindCallback: (name) ->
     @native()[name] = =>

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -31,6 +31,9 @@ class Poltergeist.WebPage
     for callback in WebPage.CALLBACKS
       this.bindCallback(callback)
 
+    if phantom.version.major < 2
+      @._overrideNativeEvaluate()
+
   for command in @COMMANDS
     do (command) =>
       this.prototype[command] =
@@ -395,3 +398,90 @@ class Poltergeist.WebPage
       clearMemoryCache()
     else
       throw new Poltergeist.UnsupportedFeature("clearMemoryCache is supported since PhantomJS 2.0.0")
+
+  _overrideNativeEvaluate: ->
+    # PhantomJS 1.9.x WebPage#evaluate depends on the browser context  JSON, this replaces it
+    # with the evaluate from 2.1.1 which uses the PhantomJS JSON
+    @_native.evaluate = `function (func, args) {
+        function quoteString(str) {
+            var c, i, l = str.length, o = '"';
+            for (i = 0; i < l; i += 1) {
+                c = str.charAt(i);
+                if (c >= ' ') {
+                    if (c === '\\' || c === '"') {
+                        o += '\\';
+                    }
+                    o += c;
+                } else {
+                    switch (c) {
+                    case '\b':
+                        o += '\\b';
+                        break;
+                    case '\f':
+                        o += '\\f';
+                        break;
+                    case '\n':
+                        o += '\\n';
+                        break;
+                    case '\r':
+                        o += '\\r';
+                        break;
+                    case '\t':
+                        o += '\\t';
+                        break;
+                    default:
+                        c = c.charCodeAt();
+                        o += '\\u00' + Math.floor(c / 16).toString(16) +
+                            (c % 16).toString(16);
+                    }
+                }
+            }
+            return o + '"';
+        }
+
+        function detectType(value) {
+            var s = typeof value;
+            if (s === 'object') {
+                if (value) {
+                    if (value instanceof Array) {
+                        s = 'array';
+                    } else if (value instanceof RegExp) {
+                        s = 'regexp';
+                    } else if (value instanceof Date) {
+                        s = 'date';
+                    }
+                } else {
+                    s = 'null';
+                }
+            }
+            return s;
+        }
+
+        var str, arg, argType, i, l;
+        if (!(func instanceof Function || typeof func === 'string' || func instanceof String)) {
+            throw "Wrong use of WebPage#evaluate";
+        }
+        str = 'function() { return (' + func.toString() + ')(';
+        for (i = 1, l = arguments.length; i < l; i++) {
+            arg = arguments[i];
+            argType = detectType(arg);
+
+            switch (argType) {
+            case "object":      //< for type "object"
+            case "array":       //< for type "array"
+                str += JSON.stringify(arg) + ","
+                break;
+            case "date":        //< for type "date"
+                str += "new Date(" + JSON.stringify(arg) + "),"
+                break;
+            case "string":      //< for type "string"
+                str += quoteString(arg) + ',';
+                break;
+            default:            // for types: "null", "number", "function", "regexp", "undefined"
+                str += arg + ',';
+                break;
+            }
+        }
+        str = str.replace(/,$/, '') + '); }';
+        return this.evaluateJavaScript(str);
+    };`

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -509,11 +509,13 @@ describe Capybara::Session do
       code = <<-JS
         (function() {
           var a = {}
+          var b = {}
           a.a = a
+          a.b = b
           return a
         })()
       JS
-      expect(@session.evaluate_script(code)).to eq('(cyclic structure)')
+      expect(@session.evaluate_script(code)).to eq({"a" => nil, "b" => {}})
     end
 
     it 'returns BR as a space in #text' do
@@ -875,6 +877,10 @@ describe Capybara::Session do
 
       it 'gets property outerHTML' do
         expect(@session.find(:css,'.some_other_class').native.property('outerHTML')).to eq '<div class="some_other_class"><p>foobar</p></div>'
+      end
+
+      it 'gets non existent property' do
+        expect(@session.find(:css,'.some_other_class').native.property('does_not_exist')).to eq nil
       end
     end
 


### PR DESCRIPTION
Due to Issue #825  I took a look at the JSON encoding and parsing being used in agent.coffee.  It turns out that evaluate has handled it itself since Poltergeist 1.5.  This PR removes the JSON storing and the encoding of values being passed to evaluate.  There are two changes this creates.  

 1.  null values returned get turned into empty string ("") when passed back to ruby - I handled this by converting them to undefined instead which gets passed back as nil.  I believe this is caused by null in the browser context != null in the phantomjs context due to being different objects but haven't actually investigated it.  

  2.  cyclic structures in returned objects are no longer detected and returned as '(cyclic structure)', rather Poltergeist breaks them by replacing any cyclic reference with undefined and returns the object.  I don't think this is a big price to pay for removing the need for storing JSON to prevent modification, etc and is an error condition that's being handled slightly differently rather than a change in normal behavior.

@route - Thoughts?
