### PR TITLE
Added CircleCI to list of CIs that have PhantomJS installed by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ was 1.0.2, so you should use that if you still need Ruby 1.8 support.
 There are no special steps to take. You don't need Xvfb or any running X
 server at all.
 
-[Travis CI](https://travis-ci.org/) and [Codeship](https://codeship.com/) has PhantomJS pre-installed.
+[Travis CI](https://travis-ci.org/), [CircleCI](https://circleci.com/) 
+and [Codeship](https://codeship.com/) has PhantomJS pre-installed.
 
 Depending on your tests, one thing that you may need is some fonts. If
 you're getting errors on a CI that don't occur during development then


### PR DESCRIPTION
Just confirmed 2.1.1 is available by default an hour ago.