### PR TITLE
Node equality needs to also compare page_id

### DIFF
--- a/lib/capybara/poltergeist/node.rb
+++ b/lib/capybara/poltergeist/node.rb
@@ -156,7 +156,7 @@ module Capybara::Poltergeist
     end
 
     def ==(other)
-      command :equals, other.id
+      (page_id == other.page_id) && command(:equals, other.id)
     end
 
     def send_keys(*keys)

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -303,6 +303,17 @@ describe Capybara::Session do
       end
     end
 
+    describe 'Node#==' do
+      it "doesn't equal a node from another page" do
+        @session.visit('/poltergeist/simple')
+        @elem1 = @session.find(:css, '#nav')
+        @session.visit('/poltergeist/set')
+        @elem2 = @session.find(:css, '#filled_div')
+        expect(@elem2 == @elem1).to be false
+        expect(@elem1 == @elem2).to be false
+      end
+    end
+
     it 'has no trouble clicking elements when the size of a document changes' do
       @session.visit('/poltergeist/long_page')
       @session.find(:css, '#penultimate').click


### PR DESCRIPTION
Node#== currently doesn't take the elements page_id into account, this means an obsolete node from a previous page is considered equal to an element from a different page with the same element id