### PR TITLE
Option to remove non permanent headers on redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Features ####
 *   Driver#evaluate_script/#execute_script accept parameters to be passed to the functions executed (Thomas Walpole)
+*   Driver#add_header can now accept ":no_redirect" for the "permanent" option
+    which removes the header on redirects or subsequent requests.
 
 #### Bug Fixes ####
 *   Node#send_keys now generates the correct key events when using the :Ctrl key and supports more of the Capybara specified key symbols (Thomas Walpole)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ was 1.0.2, so you should use that if you still need Ruby 1.8 support.
 There are no special steps to take. You don't need Xvfb or any running X
 server at all.
 
-[Travis CI](https://travis-ci.org/), [CircleCI](https://circleci.com/) 
+[Travis CI](https://travis-ci.org/), [CircleCI](https://circleci.com/)
 and [Codeship](https://codeship.com/) has PhantomJS pre-installed.
 
 Depending on your tests, one thing that you may need is some fonts. If
@@ -195,6 +195,8 @@ page.driver.headers # => { "User-Agent" => "Poltergeist" }
 
 This way your temporary headers will be sent only for the initial request, all
 subsequent request will only contain your permanent headers.
+However the temporary headers will still be sent on 30x redirects. If the
+headers should not be sent on redirects, specify `permanent: :no_redirect`.
 
 ### Inspecting network traffic ###
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -297,8 +297,8 @@ module Capybara::Poltergeist
       command 'add_headers', headers
     end
 
-    def add_header(header, permanent)
-      command 'add_header', header, permanent
+    def add_header(header, permanent, for_followed_redirect)
+      command 'add_header', header, permanent, for_followed_redirect
     end
 
     def response_headers

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -443,8 +443,10 @@ class Poltergeist.Browser
       allHeaders[name] = value
     this.set_headers(allHeaders)
 
-  add_header: (header, permanent) ->
+  add_header: (header, permanent, for_followed_redirect) ->
     @currentPage.addTempHeader(header) unless permanent
+    unless for_followed_redirect
+      @currentPage.addTempHeaderToRemoveOnRedirect(header)
     this.add_headers(header)
 
   response_headers: ->

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -624,9 +624,12 @@ Poltergeist.Browser = (function() {
     return this.set_headers(allHeaders);
   };
 
-  Browser.prototype.add_header = function(header, permanent) {
+  Browser.prototype.add_header = function(header, permanent, for_followed_redirect) {
     if (!permanent) {
       this.currentPage.addTempHeader(header);
+    }
+    if (!for_followed_redirect) {
+      this.currentPage.addTempHeaderToRemoveOnRedirect(header);
     }
     return this.add_headers(header);
   };

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -29,6 +29,7 @@ Poltergeist.WebPage = (function() {
     this._blockedUrls = [];
     this._requestedResources = {};
     this._responseHeaders = [];
+    this._tempHeadersToRemoveOnRedirect = {};
     ref = WebPage.CALLBACKS;
     for (i = 0, len = ref.length; i < len; i++) {
       callback = ref[i];
@@ -68,6 +69,7 @@ Poltergeist.WebPage = (function() {
     this.source = null;
     this.injectAgent();
     this.removeTempHeaders();
+    this.removeTempHeadersForRedirect();
     return this.setScrollPosition({
       left: 0,
       top: 0
@@ -141,6 +143,7 @@ Poltergeist.WebPage = (function() {
     } else {
       this.lastRequestId = request.id;
       if (this.normalizeURL(request.url) === this.redirectURL) {
+        this.removeTempHeadersForRedirect();
         this.redirectURL = null;
         this.requestId = request.id;
       }
@@ -164,6 +167,7 @@ Poltergeist.WebPage = (function() {
     }
     if (this.requestId === response.id) {
       if (response.redirectURL) {
+        this.removeTempHeadersForRedirect();
         this.redirectURL = this.normalizeURL(response.redirectURL);
       } else {
         this.statusCode = response.status;
@@ -420,6 +424,26 @@ Poltergeist.WebPage = (function() {
       this._tempHeaders[name] = value;
     }
     return this._tempHeaders;
+  };
+
+  WebPage.prototype.addTempHeaderToRemoveOnRedirect = function(header) {
+    var name, value;
+    for (name in header) {
+      value = header[name];
+      this._tempHeadersToRemoveOnRedirect[name] = value;
+    }
+    return this._tempHeadersToRemoveOnRedirect;
+  };
+
+  WebPage.prototype.removeTempHeadersForRedirect = function() {
+    var allHeaders, name, ref2, value;
+    allHeaders = this.getCustomHeaders();
+    ref2 = this._tempHeadersToRemoveOnRedirect;
+    for (name in ref2) {
+      value = ref2[name];
+      delete allHeaders[name];
+    }
+    return this.setCustomHeaders(allHeaders);
   };
 
   WebPage.prototype.removeTempHeaders = function() {

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -255,7 +255,14 @@ module Capybara::Poltergeist
 
     def add_header(name, value, options = {})
       permanent = options.fetch(:permanent, true)
-      browser.add_header({ name => value }, permanent)
+      if permanent == :no_redirect
+        for_followed_redirect = false
+        permanent = false
+      else
+        for_followed_redirect = true
+      end
+
+      browser.add_header({ name => value }, permanent, for_followed_redirect)
     end
 
     def response_headers

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -401,6 +401,20 @@ module Capybara::Poltergeist
         expect(ajax_request).to_not include('REFERER: http://google.com')
         expect(ajax_request).to_not include('TEMPA: a')
       end
+
+      it 'keeps added headers on redirects by default' do
+        @driver.add_header('X-Custom-Header', '1', :permanent => false)
+        @session.visit('/poltergeist/redirect_to_headers')
+        expect(@driver.body).to include('X_CUSTOM_HEADER: 1')
+      end
+
+      it 'does not keep added headers on redirect when ' \
+         'permanent is no_redirect' do
+        @driver.add_header('X-Custom-Header', '1', :permanent => :no_redirect)
+
+        @session.visit('/poltergeist/redirect_to_headers')
+        expect(@driver.body).not_to include('X_CUSTOM_HEADER: 1')
+      end
     end
 
     it 'supports clicking precise coordinates' do

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -41,6 +41,10 @@ class TestApp
     render_view 'with_different_resources'
   end
 
+  get '/poltergeist/redirect_to_headers' do
+    redirect '/poltergeist/headers'
+  end
+
   get '/poltergeist/redirect' do
     redirect '/poltergeist/with_different_resources'
   end


### PR DESCRIPTION
New option "for_followed_redirect" (Default is "true") on Driver#add_header to remove temporary headers on a redirect.