### PR TITLE
Expose the blocked_urls array to users of the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ URL whitelist of domains that are essential or a blacklist of
 domains that are not essential, such as ad networks or analytics,
 to your testing environment.
 
+You can access a unique array of blocked URLs by calling
+`page.driver.browser.blocked_urls`.
 
 ## Troubleshooting ##
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -274,6 +274,10 @@ module Capybara::Poltergeist
       command('clear_network_traffic')
     end
 
+    def blocked_urls
+      command 'blocked_urls'
+    end
+
     def set_proxy(ip, port, type, user, password)
       args = [ip, port, type]
       args << user if user

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -424,6 +424,9 @@ class Poltergeist.Browser
     @currentPage.clearNetworkTraffic()
     @current_command.sendResponse(true)
 
+  blocked_urls: ->
+    @current_command.sendResponse(@currentPage.blockedUrls())
+
   set_proxy: (ip, port, type, user, password) ->
     phantom.setProxy(ip, port, type, user, password)
     @current_command.sendResponse(true)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -597,6 +597,10 @@ Poltergeist.Browser = (function() {
     return this.current_command.sendResponse(true);
   };
 
+  Browser.prototype.blocked_urls = function() {
+    return this.current_command.sendResponse(this.currentPage.blockedUrls());
+  };
+
   Browser.prototype.set_proxy = function(ip, port, type, user, password) {
     phantom.setProxy(ip, port, type, user, password);
     return this.current_command.sendResponse(true);

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -980,6 +980,14 @@ module Capybara::Poltergeist
         end
       end
 
+      it 'tracks blocked urls' do
+        @driver.browser.url_blacklist = ['unwanted']
+
+        @session.visit '/poltergeist/url_blacklist'
+
+        expect(@driver.browser.blocked_urls).to include(/unwanted/)
+      end
+
       it 'supports wildcards' do
         @driver.browser.url_blacklist = ['*wanted']
 
@@ -1032,6 +1040,15 @@ module Capybara::Poltergeist
         @session.within_frame 'unwantedframe' do
           expect(@session).not_to have_content("We shouldn't see this.")
         end
+      end
+
+      it 'tracks blocked urls' do
+        @driver.browser.url_whitelist = ['url_whitelist', '/wanted']
+
+        @session.visit '/poltergeist/url_whitelist'
+
+        expect(@driver.browser.blocked_urls).to_not include(/url_whitelist/, /\/wanted/)
+        expect(@driver.browser.blocked_urls).to include(/unwanted/)
       end
 
       it 'supports wildcards' do


### PR DESCRIPTION
I love the url blacklist and whitelist functionality, but I've found myself occasionally wanting to print rich error messages that include information on blocked resources.

Since the browser already tracks blocked URLs internally, I think it could be helpful to expose this to gem users for debugging and error messaging purposes.

I'm open to feedback on the implementation.
