### PR TITLE
Expose blocked requests through network traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ You can inspect the network traffic (i.e. what resources have been
 loaded) on the current page by calling `page.driver.network_traffic`.
 This returns an array of request objects. A request object has a
 `response_parts` method containing data about the response chunks.
+
+You can inspect requests that were blocked by a whitelist or blacklist
+by calling `page.driver.network_traffic(:blocked)`. This returns an array of
+request objects. The `response_parts` portion of these requests will always
+be empty.
+
 Please note that network traffic is not cleared when you visit new page.
 You can manually clear the network traffic by calling `page.driver.clear_network_traffic`
 or `page.driver.reset`

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -260,13 +260,19 @@ module Capybara::Poltergeist
       command 'path', page_id, id
     end
 
-    def network_traffic
-      command('network_traffic').values.map do |event|
-        NetworkTraffic::Request.new(
-          event['request'],
-          event['responseParts'].map { |response| NetworkTraffic::Response.new(response) },
-          event['error'] ? NetworkTraffic::Error.new(event['error']) : nil
-        )
+    def network_traffic(type = nil)
+      if type == :blocked
+        command('blocked_requests').values.map do |event|
+          NetworkTraffic::Request.new(event['request'])
+        end
+      else
+        command('network_traffic').values.map do |event|
+          NetworkTraffic::Request.new(
+            event['request'],
+            event['responseParts'].map { |response| NetworkTraffic::Response.new(response) },
+            event['error'] ? NetworkTraffic::Error.new(event['error']) : nil
+          )
+        end
       end
     end
 

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -422,7 +422,11 @@ class Poltergeist.Browser
 
   clear_network_traffic: ->
     @currentPage.clearNetworkTraffic()
+    @currentPage.clearBlockedRequests()
     @current_command.sendResponse(true)
+
+  blocked_requests: ->
+    @current_command.sendResponse(@currentPage.blockedRequests())
 
   set_proxy: (ip, port, type, user, password) ->
     phantom.setProxy(ip, port, type, user, password)

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -594,7 +594,12 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.clear_network_traffic = function() {
     this.currentPage.clearNetworkTraffic();
+    this.currentPage.clearBlockedRequests();
     return this.current_command.sendResponse(true);
+  };
+
+  Browser.prototype.blocked_requests = function() {
+    return this.current_command.sendResponse(this.currentPage.blockedRequests());
   };
 
   Browser.prototype.set_proxy = function(ip, port, type, user, password) {

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -27,6 +27,7 @@ Poltergeist.WebPage = (function() {
     this._networkTraffic = {};
     this._tempHeaders = {};
     this._blockedUrls = [];
+    this._blockedRequests = {};
     this._requestedResources = {};
     this._responseHeaders = [];
     ref = WebPage.CALLBACKS;
@@ -137,6 +138,9 @@ Poltergeist.WebPage = (function() {
       if (ref2 = request.url, indexOf.call(this._blockedUrls, ref2) < 0) {
         this._blockedUrls.push(request.url);
       }
+      this._blockedRequests[request.id] = {
+        request: request
+      };
       net.abort();
     } else {
       this.lastRequestId = request.id;
@@ -309,6 +313,15 @@ Poltergeist.WebPage = (function() {
 
   WebPage.prototype.clearBlockedUrls = function() {
     this._blockedUrls = [];
+    return true;
+  };
+
+  WebPage.prototype.blockedRequests = function() {
+    return this._blockedRequests;
+  };
+
+  WebPage.prototype.clearBlockedRequests = function() {
+    this._blockedRequests = {};
     return true;
   };
 

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -26,6 +26,7 @@ class Poltergeist.WebPage
     @_networkTraffic = {}
     @_tempHeaders    = {}
     @_blockedUrls    = []
+    @_blockedRequests = {}
     @_requestedResources = {}
     @_responseHeaders = []
 
@@ -102,6 +103,11 @@ class Poltergeist.WebPage
 
     if abort
       @_blockedUrls.push request.url unless request.url in @_blockedUrls
+
+      @_blockedRequests[request.id] = {
+        request: request
+      }
+
       net.abort()
     else
       @lastRequestId = request.id
@@ -209,6 +215,13 @@ class Poltergeist.WebPage
 
   clearBlockedUrls: ->
     @_blockedUrls = []
+    return true
+
+  blockedRequests: ->
+    @_blockedRequests
+
+  clearBlockedRequests: ->
+    @_blockedRequests = {}
     return true
 
   openResourceRequests: ->

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -229,8 +229,8 @@ module Capybara::Poltergeist
       browser.scroll_to(left, top)
     end
 
-    def network_traffic
-      browser.network_traffic
+    def network_traffic(type = nil)
+      browser.network_traffic(type)
     end
 
     def clear_network_traffic

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -593,6 +593,16 @@ module Capybara::Poltergeist
         expect(urls.grep(%r{/poltergeist/test.js$}).size).to eq(1)
       end
 
+      it 'keeps track of blocked network traffic' do
+        @driver.browser.url_blacklist = ['unwanted']
+
+        @session.visit '/poltergeist/url_blacklist'
+
+        blocked_urls = @driver.network_traffic(:blocked).map(&:url)
+
+        expect(blocked_urls).to include(/unwanted/)
+      end
+
       it 'captures responses' do
         @session.visit('/poltergeist/with_js')
         request = @driver.network_traffic.last
@@ -633,6 +643,18 @@ module Capybara::Poltergeist
         @driver.clear_network_traffic
 
         expect(@driver.network_traffic.length).to eq(0)
+      end
+
+      it 'blocked requests get cleared along with network traffic' do
+        @driver.browser.url_blacklist = ['unwanted']
+
+        @session.visit '/poltergeist/url_blacklist'
+
+        expect(@driver.network_traffic(:blocked).length).to eq(2)
+
+        @driver.clear_network_traffic
+
+        expect(@driver.network_traffic(:blocked).length).to eq(0)
       end
     end
 


### PR DESCRIPTION
This is an improved implementation of #858

* Added a separate object to WebPage.coffee for tracking blocked requests
* Exposed blocked requests to gem users via `network_traffic(:blocked)`
* Made `clear_network_traffic` also clear blocked requests since these are externally represented as part of the same collection
* Added specs for `network_traffic(:blocked)` and `clear_network_traffic`
* Added documentation for `network_traffic(:blocked)`
