### PR TITLE
Specify stdin to fix hanging

### DIFF
--- a/lib/capybara/poltergeist/client.rb
+++ b/lib/capybara/poltergeist/client.rb
@@ -67,7 +67,7 @@ module Capybara::Poltergeist
         end
       }
 
-      process_options = {}
+      process_options = {in: File::NULL}
       process_options[:pgroup] = true unless Capybara::Poltergeist.windows?
       process_options[:out] = @write_io if Capybara::Poltergeist.mri?
 


### PR DESCRIPTION
Following script will hang phantomjs:

```ruby
require 'capybara/poltergeist'

server = Capybara::Poltergeist::Server.new(nil, 3, nil)
client = Capybara::Poltergeist::Client.start(server, phantomjs_logger: STDERR)
browser = Capybara::Poltergeist::Browser.new(server, client, STDERR)
browser.visit('http://example.com')
puts "Please type enter some times!"
sleep 3
browser.current_url
```

```
{"id":"b9de3899-eb70-4c99-9a0f-9d7560ed9b61","name":"visit","args":["http://example.com"]}
{"command_id":"b9de3899-eb70-4c99-9a0f-9d7560ed9b61","response":{"status":"success"}}
Please type enter some times!



{"id":"1cf43d7c-7e00-462a-b187-1faffc19e694","name":"current_url","args":[]}
/usr/local/bundle/gems/poltergeist-1.16.0/lib/capybara/poltergeist/web_socket_server.rb:100:in `rescue in send': Timed out waiting for response to {"id":"1cf43d7c-7e00-462a-b187-1faffc19e694","name":"current_url","args":[]}. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the Poltergeist :timeout option to a higher value will help (see the docs for details). If increasing the timeout does not help, this is probably a bug in Poltergeist - please report it to the issue tracker. (Capybara::Poltergeist::TimeoutError)
        from /usr/local/bundle/gems/poltergeist-1.16.0/lib/capybara/poltergeist/web_socket_server.rb:96:in `send'
        from /usr/local/bundle/gems/poltergeist-1.16.0/lib/capybara/poltergeist/server.rb:43:in `send'
        from /usr/local/bundle/gems/poltergeist-1.16.0/lib/capybara/poltergeist/browser.rb:370:in `command'
        from /usr/local/bundle/gems/poltergeist-1.16.0/lib/capybara/poltergeist/browser.rb:40:in `current_url'
        from test.rb:9:in `<main>'
```

If we don't specify `in:` option for `Process.spawn`, child process's stdin will be connected to parent (ruby) process.

```ruby
pid = Process.spawn("ruby -e 'print %(you typed -> ) + STDIN.gets'", out: $stdout)
puts "Type something"
Process.waitpid(pid)
```

```
$ ruby foo.rb
Type something
foo
you typed -> foo
```