### PR TITLE
Persist user agent and other headers across windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ This way your temporary headers will be sent only for the initial request, and r
 subsequent request will only contain your permanent headers. If the temporary
 headers should not be sent on related 30x redirects, specify `permanent: :no_redirect`.
 
+Headers set with any of these methods will be set within all windows in the
+session, with the exception of temporary headers, which are only set within the
+current window.
+
 ### Inspecting network traffic ###
 
 You can inspect the network traffic (i.e. what resources have been

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -59,6 +59,8 @@ class Poltergeist.Browser
       _page.urlBlacklist = page.urlBlacklist
       _page.urlWhitelist = page.urlWhitelist
       _page.setViewportSize(page.viewportSize())
+      _page.setUserAgent(page.getUserAgent())
+      _page.setCustomHeaders(page.getCustomHeaders())
       @setupPageHandlers(_page)
       @pages.push(_page)
 

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -60,7 +60,7 @@ class Poltergeist.Browser
       _page.urlWhitelist = page.urlWhitelist
       _page.setViewportSize(page.viewportSize())
       _page.setUserAgent(page.getUserAgent())
-      _page.setCustomHeaders(page.getCustomHeaders())
+      _page.setCustomHeaders(page.getPermanentCustomHeaders())
       @setupPageHandlers(_page)
       @pages.push(_page)
 

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -460,22 +460,23 @@ class Poltergeist.Browser
     @current_command.sendResponse(@currentPage.getCustomHeaders())
 
   set_headers: (headers) ->
-    # Workaround for https://code.google.com/p/phantomjs/issues/detail?id=745
-    @currentPage.setUserAgent(headers['User-Agent']) if headers['User-Agent']
-    @currentPage.setCustomHeaders(headers)
-    @current_command.sendResponse(true)
+    this.add_headers(headers, false, false)
 
-  add_headers: (headers) ->
-    allHeaders = @currentPage.getCustomHeaders()
-    for name, value of headers
-      allHeaders[name] = value
-    this.set_headers(allHeaders)
+  add_headers: (headers, local = false, keepExisting = true) ->
+    pages = if local then [@currentPage] else @pages
+    pages.forEach (page) =>
+      allHeaders = if keepExisting then page.getCustomHeaders() else {}
+      for name, value of headers
+        allHeaders[name] = value
+      page.setUserAgent(allHeaders['User-Agent']) if allHeaders['User-Agent']
+      page.setCustomHeaders(allHeaders)
+    @current_command.sendResponse(true)
 
   add_header: (header, { permanent = true }) ->
     unless permanent == true
       @currentPage.addTempHeader(header)
       @currentPage.addTempHeaderToRemoveOnRedirect(header) if permanent == "no_redirect"
-    this.add_headers(header)
+    this.add_headers(header, permanent != true)
 
   response_headers: ->
     @current_command.sendResponse(@currentPage.responseHeaders())

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -77,7 +77,7 @@ Poltergeist.Browser = (function() {
         _page.urlWhitelist = page.urlWhitelist;
         _page.setViewportSize(page.viewportSize());
         _page.setUserAgent(page.getUserAgent());
-        _page.setCustomHeaders(page.getCustomHeaders());
+        _page.setCustomHeaders(page.getPermanentCustomHeaders());
         _this.setupPageHandlers(_page);
         return _this.pages.push(_page);
       };

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -76,6 +76,8 @@ Poltergeist.Browser = (function() {
         _page.urlBlacklist = page.urlBlacklist;
         _page.urlWhitelist = page.urlWhitelist;
         _page.setViewportSize(page.viewportSize());
+        _page.setUserAgent(page.getUserAgent());
+        _page.setCustomHeaders(page.getCustomHeaders());
         _this.setupPageHandlers(_page);
         return _this.pages.push(_page);
       };
@@ -649,21 +651,33 @@ Poltergeist.Browser = (function() {
   };
 
   Browser.prototype.set_headers = function(headers) {
-    if (headers['User-Agent']) {
-      this.currentPage.setUserAgent(headers['User-Agent']);
-    }
-    this.currentPage.setCustomHeaders(headers);
-    return this.current_command.sendResponse(true);
+    return this.add_headers(headers, false, false);
   };
 
-  Browser.prototype.add_headers = function(headers) {
-    var allHeaders, name, value;
-    allHeaders = this.currentPage.getCustomHeaders();
-    for (name in headers) {
-      value = headers[name];
-      allHeaders[name] = value;
+  Browser.prototype.add_headers = function(headers, local, keepExisting) {
+    var pages;
+    if (local == null) {
+      local = false;
     }
-    return this.set_headers(allHeaders);
+    if (keepExisting == null) {
+      keepExisting = true;
+    }
+    pages = local ? [this.currentPage] : this.pages;
+    pages.forEach((function(_this) {
+      return function(page) {
+        var allHeaders, name, value;
+        allHeaders = keepExisting ? page.getCustomHeaders() : {};
+        for (name in headers) {
+          value = headers[name];
+          allHeaders[name] = value;
+        }
+        if (allHeaders['User-Agent']) {
+          page.setUserAgent(allHeaders['User-Agent']);
+        }
+        return page.setCustomHeaders(allHeaders);
+      };
+    })(this));
+    return this.current_command.sendResponse(true);
   };
 
   Browser.prototype.add_header = function(header, arg1) {
@@ -675,7 +689,7 @@ Poltergeist.Browser = (function() {
         this.currentPage.addTempHeaderToRemoveOnRedirect(header);
       }
     }
-    return this.add_headers(header);
+    return this.add_headers(header, permanent !== true);
   };
 
   Browser.prototype.response_headers = function() {

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -450,6 +450,22 @@ Poltergeist.WebPage = (function() {
     return this["native"]().customHeaders;
   };
 
+  WebPage.prototype.getPermanentCustomHeaders = function() {
+    var allHeaders, name, ref2, ref3, value;
+    allHeaders = this.getCustomHeaders();
+    ref2 = this._tempHeaders;
+    for (name in ref2) {
+      value = ref2[name];
+      delete allHeaders[name];
+    }
+    ref3 = this._tempHeadersToRemoveOnRedirect;
+    for (name in ref3) {
+      value = ref3[name];
+      delete allHeaders[name];
+    }
+    return allHeaders;
+  };
+
   WebPage.prototype.setCustomHeaders = function(headers) {
     return this["native"]().customHeaders = headers;
   };

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -438,6 +438,10 @@ Poltergeist.WebPage = (function() {
     }, selector);
   };
 
+  WebPage.prototype.getUserAgent = function() {
+    return this["native"]().settings.userAgent;
+  };
+
   WebPage.prototype.setUserAgent = function(userAgent) {
     return this["native"]().settings.userAgent = userAgent;
   };

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -284,6 +284,14 @@ class Poltergeist.WebPage
   getCustomHeaders: ->
     this.native().customHeaders
 
+  getPermanentCustomHeaders: ->
+    allHeaders = @getCustomHeaders()
+    for name, value of @_tempHeaders
+      delete allHeaders[name]
+    for name, value of @_tempHeadersToRemoveOnRedirect
+      delete allHeaders[name]
+    allHeaders
+
   setCustomHeaders: (headers) ->
     this.native().customHeaders = headers
 

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -275,6 +275,9 @@ class Poltergeist.WebPage
       , selector
     )
 
+  getUserAgent: ->
+    this.native().settings.userAgent
+
   setUserAgent: (userAgent) ->
     this.native().settings.userAgent = userAgent
 

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -502,6 +502,20 @@ module Capybara::Poltergeist
           expect(@driver.body).to include('HOST: foo.com')
           expect(@driver.body).to include('X_CUSTOM_HEADER: 1')
         end
+
+        it 'does not propagate temporary headers to new windows' do
+          @session.visit '/'
+          @driver.add_header('X-Custom-Header', '1', :permanent => false)
+          @session.open_new_window
+
+          @session.switch_to_window @session.windows.last
+          @session.visit('/poltergeist/headers')
+          expect(@driver.body).not_to include('X_CUSTOM_HEADER: 1')
+
+          @session.switch_to_window @session.windows.first
+          @session.visit('/poltergeist/headers')
+          expect(@driver.body).to include('X_CUSTOM_HEADER: 1')
+        end
       end
     end
 

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -439,6 +439,20 @@ module Capybara::Poltergeist
         @session.visit('/poltergeist/redirect_to_headers')
         expect(@driver.body).not_to include('X_CUSTOM_HEADER: 1')
       end
+
+      it 'persists headers across popup windows' do
+        @driver.headers = {
+          'Cookie' => 'foo=bar',
+          'Host' => 'foo.com',
+          'User-Agent' => 'foo'
+        }
+        @session.visit('/poltergeist/popup_headers')
+        @session.click_link 'pop up'
+        @session.switch_to_window @session.windows.last
+        expect(@driver.body).to include('USER_AGENT: foo')
+        expect(@driver.body).to include('COOKIE: foo=bar')
+        expect(@driver.body).to include('HOST: foo.com')
+      end
     end
 
     it 'supports clicking precise coordinates' do

--- a/spec/support/views/popup_headers.erb
+++ b/spec/support/views/popup_headers.erb
@@ -1,0 +1,1 @@
+<a href="headers" target="_blank">pop up</a>


### PR DESCRIPTION
This PR addresses #915.

The `add_header`, `add_headers`, and `set_headers` methods now set headers globally across all windows (existing windows as well as new ones). The only exception is temporary headers, which are local to the current window.