### PR TITLE
Update for Capybara 3 changes to `title` and `current_url`

### DIFF
--- a/gemfiles/Gemfile.capybara_master
+++ b/gemfiles/Gemfile.capybara_master
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'capybara', github: 'teamcapybara/capybara', branch: 'title_changes'
+gem 'capybara', github: 'teamcapybara/capybara'
 gem 'listen'
 gem 'puma'
 

--- a/gemfiles/Gemfile.capybara_master
+++ b/gemfiles/Gemfile.capybara_master
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'capybara', github: 'teamcapybara/capybara'
+gem 'capybara', github: 'teamcapybara/capybara', branch: 'title_changes'
 gem 'listen'
 gem 'puma'
 

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -43,6 +43,10 @@ module Capybara::Poltergeist
       command 'current_url'
     end
 
+    def frame_url
+      command 'frame_url'
+    end
+
     def status_code
       command 'status_code'
     end

--- a/lib/capybara/poltergeist/browser.rb
+++ b/lib/capybara/poltergeist/browser.rb
@@ -63,6 +63,10 @@ module Capybara::Poltergeist
       command 'title'
     end
 
+    def frame_title
+      command 'frame_title'
+    end
+
     def parents(page_id, id)
       command 'parents', page_id, id
     end

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -13,8 +13,8 @@ class PoltergeistAgent
   # Somehow PhantomJS returns all characters(brackets, etc) properly encoded
   # except whitespace character in pathname part of the location. This hack
   # is intended to fix this up.
-  # currentUrl: ->
-  #   window.location.href.replace(/\ /g, '%20')
+  frameUrl: ->
+    window.location.href
 
   find: (method, selector, within = document) ->
     try

--- a/lib/capybara/poltergeist/client/agent.coffee
+++ b/lib/capybara/poltergeist/client/agent.coffee
@@ -13,8 +13,8 @@ class PoltergeistAgent
   # Somehow PhantomJS returns all characters(brackets, etc) properly encoded
   # except whitespace character in pathname part of the location. This hack
   # is intended to fix this up.
-  currentUrl: ->
-    window.location.href.replace(/\ /g, '%20')
+  # currentUrl: ->
+  #   window.location.href.replace(/\ /g, '%20')
 
   find: (method, selector, within = document) ->
     try
@@ -55,7 +55,9 @@ class PoltergeistAgent
     this.get(id).removeAttribute('_poltergeist_selected')
 
   clearLocalStorage: ->
-    localStorage?.clear()
+    try
+      localStorage?.clear()
+    catch error
 
   wrapResults: (result, page_id)->
     @_visitedObjects ||= [];

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -18,7 +18,6 @@ class Poltergeist.Browser
 
     if @page?
       unless @page.closed
-        # @page.clearLocalStorage() if @page.currentUrl() != 'about:blank'
         @page.clearLocalStorage() if @page.frameUrl() != 'about:blank'
         @page.close()
       phantom.clearCookies()

--- a/lib/capybara/poltergeist/client/browser.coffee
+++ b/lib/capybara/poltergeist/client/browser.coffee
@@ -18,7 +18,8 @@ class Poltergeist.Browser
 
     if @page?
       unless @page.closed
-        @page.clearLocalStorage() if @page.currentUrl() != 'about:blank'
+        # @page.clearLocalStorage() if @page.currentUrl() != 'about:blank'
+        @page.clearLocalStorage() if @page.frameUrl() != 'about:blank'
         @page.close()
       phantom.clearCookies()
 
@@ -129,6 +130,9 @@ class Poltergeist.Browser
   current_url: ->
     @current_command.sendResponse @currentPage.currentUrl()
 
+  frame_url: ->
+    @current_command.sendResponse @currentPage.frameUrl()
+
   status_code: ->
     @current_command.sendResponse @currentPage.statusCode
 
@@ -140,6 +144,9 @@ class Poltergeist.Browser
 
   title: ->
     @current_command.sendResponse @currentPage.title()
+
+  frame_title: ->
+    @current_command.sendResponse @currentPage.frameTitle()
 
   find: (method, selector) ->
     @current_command.sendResponse(page_id: @currentPage.id, ids: @currentPage.find(method, selector))
@@ -230,8 +237,8 @@ class Poltergeist.Browser
     @currentPage.execute("function() { #{script} }", args...)
     @current_command.sendResponse(true)
 
-  frameUrl: (frame_name) ->
-    @currentPage.frameUrl(frame_name)
+  frameUrlFor: (frame_name) ->
+    @currentPage.frameUrlFor(frame_name)
 
   pushFrame: (command, name, timeout) ->
     if Array.isArray(name)
@@ -241,11 +248,12 @@ class Poltergeist.Browser
         frame.setAttribute('name', "_random_name_#{new Date().getTime()}")
         name = frame.getAttribute('name')
 
-    frame_url = @frameUrl(name)
+    frame_url = @frameUrlFor(name)
     if frame_url in @currentPage.blockedUrls()
       command.sendResponse(true)
     else if @currentPage.pushFrame(name)
-      if frame_url && (frame_url != 'about:blank') && (@currentPage.currentUrl() == 'about:blank')
+      # if frame_url && (frame_url != 'about:blank') && (@currentPage.currentUrl() == 'about:blank')
+      if frame_url && (frame_url != 'about:blank') && (@currentPage.frameUrl() == 'about:blank')
         @currentPage.state = 'awaiting_frame_load'
         @currentPage.waitState 'default', ->
           command.sendResponse(true)

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -25,10 +25,6 @@ PoltergeistAgent = (function() {
     }
   };
 
-  PoltergeistAgent.prototype.currentUrl = function() {
-    return window.location.href.replace(/\ /g, '%20');
-  };
-
   PoltergeistAgent.prototype.find = function(method, selector, within) {
     var el, error, i, j, len, results, results1, xpath;
     if (within == null) {
@@ -99,7 +95,12 @@ PoltergeistAgent = (function() {
   };
 
   PoltergeistAgent.prototype.clearLocalStorage = function() {
-    return typeof localStorage !== "undefined" && localStorage !== null ? localStorage.clear() : void 0;
+    var error;
+    try {
+      return typeof localStorage !== "undefined" && localStorage !== null ? localStorage.clear() : void 0;
+    } catch (error1) {
+      error = error1;
+    }
   };
 
   PoltergeistAgent.prototype.wrapResults = function(result, page_id) {

--- a/lib/capybara/poltergeist/client/compiled/agent.js
+++ b/lib/capybara/poltergeist/client/compiled/agent.js
@@ -25,6 +25,10 @@ PoltergeistAgent = (function() {
     }
   };
 
+  PoltergeistAgent.prototype.frameUrl = function() {
+    return window.location.href;
+  };
+
   PoltergeistAgent.prototype.find = function(method, selector, within) {
     var el, error, i, j, len, results, results1, xpath;
     if (within == null) {

--- a/lib/capybara/poltergeist/client/compiled/browser.js
+++ b/lib/capybara/poltergeist/client/compiled/browser.js
@@ -20,7 +20,7 @@ Poltergeist.Browser = (function() {
     ref = [0, []], this._counter = ref[0], this.pages = ref[1];
     if (this.page != null) {
       if (!this.page.closed) {
-        if (this.page.currentUrl() !== 'about:blank') {
+        if (this.page.frameUrl() !== 'about:blank') {
           this.page.clearLocalStorage();
         }
         this.page.close();
@@ -160,6 +160,10 @@ Poltergeist.Browser = (function() {
     return this.current_command.sendResponse(this.currentPage.currentUrl());
   };
 
+  Browser.prototype.frame_url = function() {
+    return this.current_command.sendResponse(this.currentPage.frameUrl());
+  };
+
   Browser.prototype.status_code = function() {
     return this.current_command.sendResponse(this.currentPage.statusCode);
   };
@@ -174,6 +178,10 @@ Poltergeist.Browser = (function() {
 
   Browser.prototype.title = function() {
     return this.current_command.sendResponse(this.currentPage.title());
+  };
+
+  Browser.prototype.frame_title = function() {
+    return this.current_command.sendResponse(this.currentPage.frameTitle());
   };
 
   Browser.prototype.find = function(method, selector) {
@@ -311,8 +319,8 @@ Poltergeist.Browser = (function() {
     return this.current_command.sendResponse(true);
   };
 
-  Browser.prototype.frameUrl = function(frame_name) {
-    return this.currentPage.frameUrl(frame_name);
+  Browser.prototype.frameUrlFor = function(frame_name) {
+    return this.currentPage.frameUrlFor(frame_name);
   };
 
   Browser.prototype.pushFrame = function(command, name, timeout) {
@@ -325,11 +333,11 @@ Poltergeist.Browser = (function() {
         name = frame.getAttribute('name');
       }
     }
-    frame_url = this.frameUrl(name);
+    frame_url = this.frameUrlFor(name);
     if (indexOf.call(this.currentPage.blockedUrls(), frame_url) >= 0) {
       return command.sendResponse(true);
     } else if (this.currentPage.pushFrame(name)) {
-      if (frame_url && (frame_url !== 'about:blank') && (this.currentPage.currentUrl() === 'about:blank')) {
+      if (frame_url && (frame_url !== 'about:blank') && (this.currentPage.frameUrl() === 'about:blank')) {
         this.currentPage.state = 'awaiting_frame_load';
         return this.currentPage.waitState('default', function() {
           return command.sendResponse(true);

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -378,7 +378,11 @@ Poltergeist.WebPage = (function() {
   };
 
   WebPage.prototype.frameUrl = function() {
-    return this["native"]().frameUrl;
+    if (phantom.version.major > 2 || (phantom.version.major === 2 && phantom.version.minor >= 1)) {
+      return this["native"]().frameUrl;
+    } else {
+      return this.runCommand('frameUrl');
+    }
   };
 
   WebPage.prototype.frameUrlFor = function(frameNameOrId) {

--- a/lib/capybara/poltergeist/client/compiled/web_page.js
+++ b/lib/capybara/poltergeist/client/compiled/web_page.js
@@ -8,9 +8,9 @@ Poltergeist.WebPage = (function() {
 
   WebPage.CALLBACKS = ['onConsoleMessage', 'onError', 'onLoadFinished', 'onInitialized', 'onLoadStarted', 'onResourceRequested', 'onResourceReceived', 'onResourceError', 'onNavigationRequested', 'onUrlChanged', 'onPageCreated', 'onClosing', 'onCallback'];
 
-  WebPage.DELEGATES = ['open', 'sendEvent', 'uploadFile', 'render', 'close', 'renderBase64', 'goBack', 'goForward', 'reload'];
+  WebPage.DELEGATES = ['url', 'open', 'sendEvent', 'uploadFile', 'render', 'close', 'renderBase64', 'goBack', 'goForward', 'reload'];
 
-  WebPage.COMMANDS = ['currentUrl', 'find', 'nodeCall', 'documentSize', 'beforeUpload', 'afterUpload', 'clearLocalStorage'];
+  WebPage.COMMANDS = ['find', 'nodeCall', 'documentSize', 'beforeUpload', 'afterUpload', 'clearLocalStorage'];
 
   WebPage.EXTENSIONS = [];
 
@@ -366,10 +366,22 @@ Poltergeist.WebPage = (function() {
   };
 
   WebPage.prototype.title = function() {
+    return this["native"]().title;
+  };
+
+  WebPage.prototype.frameTitle = function() {
     return this["native"]().frameTitle;
   };
 
-  WebPage.prototype.frameUrl = function(frameNameOrId) {
+  WebPage.prototype.currentUrl = function() {
+    return this["native"]().url;
+  };
+
+  WebPage.prototype.frameUrl = function() {
+    return this["native"]().frameUrl;
+  };
+
+  WebPage.prototype.frameUrlFor = function(frameNameOrId) {
     var query;
     query = function(frameNameOrId) {
       var ref2;

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -231,7 +231,10 @@ class Poltergeist.WebPage
     @native().url
 
   frameUrl: ->
-    @native().frameUrl
+    if phantom.version.major > 2 || (phantom.version.major == 2 && phantom.version.minor >= 1)
+      @native().frameUrl
+    else
+      @runCommand('frameUrl')
 
   frameUrlFor: (frameNameOrId) ->
     query = (frameNameOrId) ->

--- a/lib/capybara/poltergeist/client/web_page.coffee
+++ b/lib/capybara/poltergeist/client/web_page.coffee
@@ -5,10 +5,11 @@ class Poltergeist.WebPage
                 'onNavigationRequested', 'onUrlChanged', 'onPageCreated',
                 'onClosing', 'onCallback']
 
-  @DELEGATES = ['open', 'sendEvent', 'uploadFile', 'render', 'close',
+  @DELEGATES = ['url', 'open', 'sendEvent', 'uploadFile', 'render', 'close',
                 'renderBase64', 'goBack', 'goForward', 'reload']
 
-  @COMMANDS  = ['currentUrl', 'find', 'nodeCall', 'documentSize',
+  # @COMMANDS  = ['currentUrl', 'find', 'nodeCall', 'documentSize',
+  @COMMANDS  = ['find', 'nodeCall', 'documentSize',
                 'beforeUpload', 'afterUpload', 'clearLocalStorage']
 
   @EXTENSIONS = []
@@ -221,9 +222,18 @@ class Poltergeist.WebPage
     this.native().frameContent
 
   title: ->
+    this.native().title
+
+  frameTitle: ->
     this.native().frameTitle
 
-  frameUrl: (frameNameOrId) ->
+  currentUrl: ->
+    @native().url
+
+  frameUrl: ->
+    @native().frameUrl
+
+  frameUrlFor: (frameNameOrId) ->
     query = (frameNameOrId) ->
       document.querySelector("iframe[name='#{frameNameOrId}'], iframe[id='#{frameNameOrId}']")?.src
     this.evaluate(query, frameNameOrId)

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -100,7 +100,15 @@ module Capybara::Poltergeist
     end
 
     def current_url
-      browser.current_url
+      if Capybara::VERSION.to_f < 3.0
+        frame_url
+      else
+        browser.current_url
+      end
+    end
+
+    def frame_url
+      browser.frame_url
     end
 
     def status_code

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -103,12 +103,12 @@ module Capybara::Poltergeist
       if Capybara::VERSION.to_f < 3.0
         frame_url
       else
-        browser.current_url
+        browser.current_url.gsub(' ', '%20') # PhantomJS < 2.1 doesn't escape spaces
       end
     end
 
     def frame_url
-      browser.frame_url
+      browser.frame_url.gsub(' ', '%20') # PhantomJS < 2.1 doesn't escape spaces
     end
 
     def status_code
@@ -125,7 +125,15 @@ module Capybara::Poltergeist
     end
 
     def title
-      browser.title
+      if Capybara::VERSION.to_f < 3.0
+        frame_title
+      else
+        browser.title
+      end
+    end
+
+    def frame_title
+      browser.frame_title
     end
 
     def find(method, selector)

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -1445,5 +1445,23 @@ module Capybara::Poltergeist
         end
       end
     end
+
+    context 'URL' do
+      it 'can get the frames url' do
+        @session.visit '/poltergeist/frames'
+
+        @session.within_frame 0 do
+          expect(@session.driver.frame_url).to end_with('/poltergeist/slow')
+          if Capybara::VERSION.to_f < 3.0
+            expect(@session.driver.current_url).to end_with('/poltergeist/slow')
+          else
+            # current_url is required to return the top level browsing context in Capybara 3
+            expect(@session.driver.current_url).to end_with('/poltergeist/frames')
+          end
+        end
+        expect(@session.driver.frame_url).to end_with('/poltergeist/frames')
+        expect(@session.driver.current_url).to end_with('/poltergeist/frames')
+      end
+    end
   end
 end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -659,7 +659,7 @@ describe Capybara::Session do
         @session.visit '/poltergeist/frames'
 
         @session.within_frame 0 do
-          expect(@session.current_path).to eq('/poltergeist/slow')
+          expect(@session.driver.frame_url).to end_with('/poltergeist/slow')
         end
       end
 
@@ -668,7 +668,7 @@ describe Capybara::Session do
         frame = @session.find(:css, 'iframe[name]')
 
         @session.within_frame(frame) do
-          expect(@session.current_path).to eq('/poltergeist/slow')
+          expect(@session.driver.frame_url).to end_with('/poltergeist/slow')
         end
       end
 
@@ -677,7 +677,7 @@ describe Capybara::Session do
         frame = @session.find(:css, 'iframe:not([name]):not([id])')
 
         @session.within_frame(frame) do
-          expect(@session.current_path).to eq('/poltergeist/headers')
+          expect(@session.driver.frame_url).to end_with('/poltergeist/headers')
         end
       end
 
@@ -686,7 +686,7 @@ describe Capybara::Session do
         frame = @session.find(:css, 'iframe[id]:not([name])')
 
         @session.within_frame(frame) do
-          expect(@session.current_path).to eq('/poltergeist/get_cookie')
+          expect(@session.driver.frame_url).to end_with('/poltergeist/get_cookie')
         end
       end
 
@@ -698,11 +698,10 @@ describe Capybara::Session do
         JS
 
         @session.within_frame 'frame' do
-          expect(@session.current_path).to eq('/poltergeist/slow')
+          expect(@session.driver.frame_url).to end_with('/poltergeist/slow')
           expect(@session.html).to include('slow page')
         end
-
-        expect(@session.current_path).to eq('/')
+        expect(URI.parse(@session.driver.frame_url).path).to eq('/')
       end
 
       it 'waits for the cross-domain frame to load' do
@@ -710,11 +709,11 @@ describe Capybara::Session do
         expect(@session.current_path).to eq('/poltergeist/frames')
 
         @session.within_frame 'frame' do
-          expect(@session.current_path).to eq('/poltergeist/slow')
+          expect(@session.driver.frame_url).to end_with('/poltergeist/slow')
           expect(@session.body).to include('slow page')
         end
 
-        expect(@session.current_path).to eq('/poltergeist/frames')
+        expect(@session.driver.frame_url).to end_with('/poltergeist/frames')
       end
 
       context "with src == about:blank" do


### PR DESCRIPTION
Capybara 3 defines `title` and `current_url` to refer to the top level browsing context to match the WebDriver spec.  This changes the behavior of those methods when using Capybara 3+ and also adds the Driver#frame_title and Driver#frame_url methods to access frame specific title and url