### PR TITLE
Removed overriding

### DIFF
--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -54,11 +54,14 @@ module Capybara::Poltergeist
     def phantomjs_options
       list = options[:phantomjs_options] || []
 
-      # PhantomJS defaults to only using SSLv3, which since POODLE (Oct 2014)
-      # many sites have dropped from their supported protocols (eg PayPal,
-      # Braintree).
+      # Since 4 years ago, phantomjs ssl protocol default was changed
+      # from SSLv3 into TLS1.0 or newer versions such as 1.1 and 1.2,
+      # so there is no meaning setting protocol as TLSv1.
+      # Moreover, TLSv1 is interpreted in phantomjs as TLS1.0 (not TLSv1.0 or newer),
+      # so in some websites which uses only TLS1.1 or newer
+      # cannot be accessed by TLSv1.
+      
       list += ["--ignore-ssl-errors=yes"] unless list.grep(/ignore-ssl-errors/).any?
-      list += ["--ssl-protocol=TLSv1"] unless list.grep(/ssl-protocol/).any?
       list += ["--remote-debugger-port=#{inspector.port}", "--remote-debugger-autorun=yes"] if inspector
       list
     end

--- a/lib/capybara/poltergeist/driver.rb
+++ b/lib/capybara/poltergeist/driver.rb
@@ -60,8 +60,9 @@ module Capybara::Poltergeist
       # Moreover, TLSv1 is interpreted in phantomjs as TLS1.0 (not TLSv1.0 or newer),
       # so in some websites which uses only TLS1.1 or newer
       # cannot be accessed by TLSv1.
-      
+
       list += ["--ignore-ssl-errors=yes"] unless list.grep(/ignore-ssl-errors/).any?
+      list += ["--ssl-protocol=default"] unless list.grep(/ssl-protocol/).any?
       list += ["--remote-debugger-port=#{inspector.port}", "--remote-debugger-autorun=yes"] if inspector
       list
     end


### PR DESCRIPTION
PhantomJS used to default to only using SSLv3 and someone thought this is inappropriate so s/he overrode the default into TLSv1.
However, about 4 yrs ago PhantomJS changed its default SSL protocol from SSLv3 into TLS1.0 or newer versions, so there is no meaning overriding the default.

Furthermore, "TLSv1" seems to be equal to "TLSv1.0 or newer", but actually it is "TLSv1.0 only".
So, there comes the problem. 
In some websites which uses only TLSv1.1 or newer will not accept access in protocol TLSv1.

In this way, poltergeist's PhantomJS default option "--ssl-protocol=TLSv1" is no more necessary and sometimes troubling.