### PR TITLE
Update Homebrew installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dependencies* (you don't need Qt, or a running X server, etc.)
 
 ### Mac ###
 
-* *Homebrew*: `brew install phantomjs`
+* *Homebrew*: `brew tap homebrew/cask && brew cask install phantomjs`
 * *MacPorts*: `sudo port install phantomjs`
 * *Manual install*: [Download this](https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-macosx.zip)
 


### PR DESCRIPTION
```
~> brew install phantomjs
Error: No available formula with the name "phantomjs" 
It was migrated from homebrew/core to homebrew/cask.
You can access it again by running:
  brew tap homebrew/cask
And then you can install it by running:
  brew cask install phantomjs
```